### PR TITLE
[Mdb] Mdb(Mono debug symbols file) emitting support added

### DIFF
--- a/Src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/Src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -566,6 +566,12 @@
     <Compile Include="WellKnownMembers.cs" />
     <Compile Include="WellKnownTypes.cs" />
     <Compile Include="Xml\XmlCharType.cs" />
+    <Compile Include="PEWriter\MdbWriter\MdbWriter.cs" />
+    <Compile Include="PEWriter\MdbWriter\MonoSymbolFile.cs" />
+    <Compile Include="PEWriter\MdbWriter\MonoSymbolTable.cs" />
+    <Compile Include="PEWriter\MdbWriter\MonoSymbolWriter.cs" />
+    <Compile Include="PEWriter\MdbWriter\SourceMethodBuilder.cs" />
+    <Compile Include="PEWriter\MdbWriter\PclFileAccess.cs" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Desktop" />

--- a/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MdbWriter.cs
+++ b/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MdbWriter.cs
@@ -1,0 +1,311 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices.ComTypes;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Utilities;
+
+namespace Mono.CompilerServices.SymbolWriter
+{
+	class MdbWriter : ISymUnmanagedWriter2, ISymUnmanagedWriter5
+	{
+		MonoSymbolWriter msw;
+		int nextLocalIndex;
+
+		Dictionary<string,SymbolDocumentWriterImpl> documents = new Dictionary<string, SymbolDocumentWriterImpl> ();
+
+		#region ISymUnmanagedWriter2 implementation
+
+
+		MetadataWriter writer;
+
+		public void Initialize (object emitter, string filename, object ptrIStream, bool fullBuild)
+		{
+			var writerField = typeof(PdbMetadataWrapper).GetRuntimeFields ().First ((f) => f.Name == "writer");
+			writer = (MetadataWriter)writerField.GetValue (emitter);
+
+			if (filename.EndsWith (".mdb")) {
+				//In case Roslyn adapts to point stream at .mdb... Use that stream instead of opening file
+				var stream = (Stream)typeof(ComStreamWrapper).GetRuntimeFields ().First ((f) => f.Name == "stream").GetValue (ptrIStream);
+				msw = new MonoSymbolWriter (stream);
+			} else {
+				//Change .pdb to .exe or .dll
+				filename = Path.ChangeExtension (filename, Path.GetExtension (writer.Context.Module.ModuleName));
+				msw = new MonoSymbolWriter (filename);
+				//Notice that Roslyn opened stream for us that is pointing at .pdb but will be empty(length==0) after compilation finishes because we
+				//didn't write anything into that stream.
+			}
+		}
+
+		public void OpenMethod (uint method)
+		{
+			var sm = new SourceMethodImpl (writer.GetMethodDefinition (method).Name, (int)method);
+			msw.OpenMethod (null, 0, sm);
+		}
+
+		public ISymUnmanagedDocumentWriter DefineDocument (string url, ref Guid language, ref Guid languageVendor, ref Guid documentType)
+		{
+			SymbolDocumentWriterImpl doc;
+			if (!documents.TryGetValue (url, out doc)) {
+				SourceFileEntry entry = msw.DefineDocument (url);
+				CompileUnitEntry comp_unit = msw.DefineCompilationUnit (entry);
+				doc = new SymbolDocumentWriterImpl (comp_unit);
+				documents.Add (url, doc);
+			}
+			return doc;
+		}
+
+		public void CloseMethod ()
+		{
+			nextLocalIndex = 0;
+			msw.CloseMethod ();
+		}
+
+		public uint OpenScope (uint startOffset)
+		{
+			return (uint)msw.OpenScope ((int)startOffset);
+		}
+
+		public void CloseScope (uint endOffset)
+		{
+			msw.CloseScope ((int)endOffset);
+		}
+
+		public void Close ()
+		{
+			Guid moduleVersionId;
+			var guidIndex = (Dictionary<Guid, uint>)typeof(MetadataWriter).GetRuntimeFields ().First ((f) => f.Name == "guidIndex").GetValue (writer);
+			foreach (var pair in guidIndex) {
+				if (pair.Value == 1) {
+					moduleVersionId = pair.Key;
+					break;
+				}
+			}
+			msw.WriteSymbolFile (moduleVersionId);
+		}
+
+		#region Used by Roslyn but not implemented
+
+		public void SetSymAttribute (uint parent, string name, uint data, IntPtr signature)
+		{
+			//Roslyn is calling this with name=="MD2" but not sure if .mdb has anything that could use this data
+		}
+
+		public void SetUserEntryPoint (uint entryMethod)
+		{
+			//.mdb doesn't have counterpart for this
+		}
+
+		public void UsingNamespace (string fullName)
+		{
+			//Not used in Mono runtime but seems to be in .mdb not sure what is use for this
+		}
+
+		public void DefineConstant2 (string name, VariantStructure value, uint sigToken)
+		{
+			//Mdb doesn't support constant values.
+			//Constant values are lost at compile time and are not part of ILs/Stack.
+			//So in case of PDB this values are stored inside PDB so debugger can display this values in IDE.
+			//But in case of MDB. IDE displays this values from SyntaxTree knowledge. This has drawback
+			//this value can be seen only by hovering mouse over constant name in code and can't be visible in Locals as
+			//in case of PDB.(in theory TypeSystem/SyntaxTree could inform Locals about constants in current method)
+		}
+
+		#endregion
+
+		public void GetDebugInfo (ref ImageDebugDirectory ptrIDD, uint dataCount, out uint dataCountPtr, IntPtr data)
+		{
+			dataCountPtr = 0;
+		}
+
+		public void DefineSequencePoints (ISymUnmanagedDocumentWriter document, uint count, uint[] offsets, uint[] lines, uint[] columns, uint[] endLines, uint[] endColumns)
+		{
+			msw.SetMethodUnit (((ICompileUnit)document).Entry);
+			var doc = (SymbolDocumentWriterImpl)document;
+			var file = doc != null ? doc.Entry.SourceFile : null;
+			for (int n = 0; n < count; n++) {
+				if (n > 0 && offsets [n] == offsets [n - 1] && lines [n] == lines [n - 1] && columns [n] == columns [n - 1])
+					continue;
+				msw.MarkSequencePoint ((int)offsets [n], file, (int)lines [n], (int)columns [n], (int)endLines [n], (int)endColumns [n], lines [n] == 0xfeefee);
+			}
+		}
+
+		public void DefineLocalVariable2 (string name, uint attributes, uint sigToken, uint addrKind, uint addr1, uint addr2, uint addr3, uint startOffset, uint endOffset)
+		{
+			msw.DefineLocalVariable (nextLocalIndex++, name);
+		}
+
+		#endregion
+
+		#region Unimplemented methods which are also not used by Roslyn
+
+		public class NotUsedInRoslynException : Exception
+		{
+			public NotUsedInRoslynException () :
+				base ("Method was called in MdbWriter that was not used by Roslyn in past. Need to implement this method.")
+			{
+
+			}
+		}
+
+		public void DefineLocalVariable (string name, uint attributes, uint sig, IntPtr signature, uint addrKind, uint addr1, uint addr2, uint startOffset, uint endOffset)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void DefineField (uint parent, string name, uint attributes, uint sig, IntPtr signature, uint addrKind, uint addr1, uint addr2, uint addr3)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void DefineGlobalVariable2 (string name, uint attributes, uint sigToken, uint addrKind, uint addr1, uint addr2, uint addr3)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void OpenNamespace (string name)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void CloseNamespace ()
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void RemapToken (uint oldToken, uint newToken)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void Initialize2 (object emitter, string tempfilename, object ptrIStream, bool fullBuild, string finalfilename)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void DefineConstant (string name, object value, uint sig, IntPtr signature)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void Abort ()
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void SetMethodSourceRange (ISymUnmanagedDocumentWriter startDoc, uint startLine, uint startColumn, object endDoc, uint endLine, uint endColumn)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void SetScopeRange (uint scopeID, uint startOffset, uint endOffset)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void DefineParameter (string name, uint attributes, uint sequence, uint addrKind, uint addr1, uint addr2, uint addr3)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void DefineGlobalVariable (string name, uint attributes, uint sig, IntPtr signature, uint addrKind, uint addr1, uint addr2, uint addr3)
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		#region ISymUnmanagedWriter5 implementation
+
+		public void _VtblGap1_30 ()
+		{
+			throw new NotUsedInRoslynException ();
+		}
+
+		public void OpenMapTokensToSourceSpans ()
+		{
+			var assembly = writer.Context.Module.AsAssembly;
+			if (assembly != null && assembly.Kind == ModuleKind.WindowsRuntimeMetadata) {
+				//I guess Mono doesn't care about .winmdobj file generation
+			} else {
+				throw new NotUsedInRoslynException ();
+			}
+		}
+
+		public void CloseMapTokensToSourceSpans ()
+		{
+			var assembly = writer.Context.Module.AsAssembly;
+			if (assembly != null && assembly.Kind == ModuleKind.WindowsRuntimeMetadata) {
+				//I guess Mono doesn't care about .winmdobj file generation
+			} else {
+				throw new NotUsedInRoslynException ();
+			}
+		}
+
+		public void MapTokenToSourceSpan (uint token, ISymUnmanagedDocumentWriter document, uint startLine, uint startColumn, uint endLine, uint endColumn)
+		{
+			var assembly = writer.Context.Module.AsAssembly;
+			if (assembly != null && assembly.Kind == ModuleKind.WindowsRuntimeMetadata) {
+				//I guess Mono doesn't care about .winmdobj file generation
+			} else {
+				throw new NotUsedInRoslynException ();
+			}
+		}
+
+		#endregion
+
+		#endregion
+	}
+
+	class SourceMethodImpl: IMethodDef
+	{
+		string name;
+		int token;
+
+		public SourceMethodImpl (string name, int token)
+		{
+			this.name = name;
+			this.token = token;
+		}
+
+		public string Name {
+			get { return name; }
+		}
+
+		public int Token {
+			get { return token; }
+		}
+	}
+
+
+	class SymbolDocumentWriterImpl: ISymUnmanagedDocumentWriter, ISourceFile, ICompileUnit
+	{
+		CompileUnitEntry comp_unit;
+
+		public SymbolDocumentWriterImpl (CompileUnitEntry comp_unit)
+		{
+			this.comp_unit = comp_unit;
+		}
+
+		SourceFileEntry ISourceFile.Entry {
+			get { return comp_unit.SourceFile; }
+		}
+
+		public CompileUnitEntry Entry {
+			get { return comp_unit; }
+		}
+
+		#region ISymUnmanagedDocumentWriter implementation
+
+		public void SetSource (uint sourceSize, byte[] source)
+		{
+		}
+
+		public void SetCheckSum (Guid algorithmId, uint checkSumSize, byte[] checkSum)
+		{
+		}
+
+		#endregion
+	}
+}

--- a/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MonoSymbolFile.cs
+++ b/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MonoSymbolFile.cs
@@ -1,0 +1,626 @@
+//
+// MonoSymbolFile.cs
+//
+// Authors:
+//   Martin Baulig (martin@ximian.com)
+//   Marek Safar (marek.safar@gmail.com)
+//
+// (C) 2003 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2012 Xamarin Inc (http://www.xamarin.com)
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.IO;
+	
+namespace Mono.CompilerServices.SymbolWriter
+{
+	public class MonoSymbolFileException : Exception
+	{
+		public MonoSymbolFileException ()
+			: base ()
+		{ }
+
+		public MonoSymbolFileException (string message, params object[] args)
+			: base (String.Format (message, args))
+		{
+		}
+
+		public MonoSymbolFileException (string message, Exception innerException)
+			: base (message, innerException)
+		{
+		}
+	}
+
+	sealed class MyBinaryWriter : System.IO.BinaryWriter
+	{
+		public MyBinaryWriter (Stream stream)
+			: base (stream)
+		{ }
+
+		public void WriteLeb128 (int value)
+		{
+			base.Write7BitEncodedInt (value);
+		}
+	}
+
+	internal class MyBinaryReader : BinaryReader
+	{
+		public MyBinaryReader (Stream stream)
+			: base (stream)
+		{ }
+
+		public int ReadLeb128 ()
+		{
+			return base.Read7BitEncodedInt ();
+		}
+
+		public string ReadString (int offset)
+		{
+			long old_pos = BaseStream.Position;
+			BaseStream.Position = offset;
+
+			string text = ReadString ();
+
+			BaseStream.Position = old_pos;
+			return text;
+		}
+	}
+
+	public interface ISourceFile
+	{
+		SourceFileEntry Entry {
+			get;
+		}
+	}
+
+	public interface ICompileUnit
+	{
+		CompileUnitEntry Entry {
+			get;
+		}
+	}
+
+	public interface IMethodDef
+	{
+		string Name {
+			get;
+		}
+
+		int Token {
+			get;
+		}
+	}
+
+	public class MonoSymbolFile : IDisposable
+	{
+		List<MethodEntry> methods = new List<MethodEntry> ();
+		List<SourceFileEntry> sources = new List<SourceFileEntry> ();
+		List<CompileUnitEntry> comp_units = new List<CompileUnitEntry> ();
+		Dictionary<int, AnonymousScopeEntry> anonymous_scopes;
+
+		OffsetTable ot;
+		int last_type_index;
+		int last_method_index;
+		int last_namespace_index;
+
+		public readonly int MajorVersion = OffsetTable.MajorVersion;
+		public readonly int MinorVersion = OffsetTable.MinorVersion;
+
+		public int NumLineNumbers;
+
+		public MonoSymbolFile ()
+		{
+			ot = new OffsetTable ();
+		}
+
+		public int AddSource (SourceFileEntry source)
+		{
+			sources.Add (source);
+			return sources.Count;
+		}
+
+		public int AddCompileUnit (CompileUnitEntry entry)
+		{
+			comp_units.Add (entry);
+			return comp_units.Count;
+		}
+
+		public void AddMethod (MethodEntry entry)
+		{
+			methods.Add (entry);
+		}
+
+		public MethodEntry DefineMethod (CompileUnitEntry comp_unit, int token,
+						 ScopeVariable[] scope_vars, LocalVariableEntry[] locals,
+						 LineNumberEntry[] lines, CodeBlockEntry[] code_blocks,
+						 string real_name, MethodEntry.Flags flags,
+						 int namespace_id)
+		{
+			if (reader != null)
+				throw new InvalidOperationException ();
+
+			MethodEntry method = new MethodEntry (
+				this, comp_unit, token, scope_vars, locals, lines, code_blocks, 
+				real_name, flags, namespace_id);
+			AddMethod (method);
+			return method;
+		}
+
+		internal void DefineAnonymousScope (int id)
+		{
+			if (reader != null)
+				throw new InvalidOperationException ();
+
+			if (anonymous_scopes == null)
+				anonymous_scopes = new Dictionary<int, AnonymousScopeEntry>  ();
+
+			anonymous_scopes.Add (id, new AnonymousScopeEntry (id));
+		}
+
+		internal void DefineCapturedVariable (int scope_id, string name, string captured_name,
+						      CapturedVariable.CapturedKind kind)
+		{
+			if (reader != null)
+				throw new InvalidOperationException ();
+
+			AnonymousScopeEntry scope = anonymous_scopes [scope_id];
+			scope.AddCapturedVariable (name, captured_name, kind);
+		}
+
+		internal void DefineCapturedScope (int scope_id, int id, string captured_name)
+		{
+			if (reader != null)
+				throw new InvalidOperationException ();
+
+			AnonymousScopeEntry scope = anonymous_scopes [scope_id];
+			scope.AddCapturedScope (id, captured_name);
+		}
+
+		internal int GetNextTypeIndex ()
+		{
+			return ++last_type_index;
+		}
+
+		internal int GetNextMethodIndex ()
+		{
+			return ++last_method_index;
+		}
+
+		internal int GetNextNamespaceIndex ()
+		{
+			return ++last_namespace_index;
+		}
+		
+		void Write (MyBinaryWriter bw, Guid guid)
+		{
+			// Magic number and file version.
+			bw.Write (OffsetTable.Magic);
+			bw.Write (MajorVersion);
+			bw.Write (MinorVersion);
+
+			bw.Write (guid.ToByteArray ());
+
+			//
+			// Offsets of file sections; we must write this after we're done
+			// writing the whole file, so we just reserve the space for it here.
+			//
+			long offset_table_offset = bw.BaseStream.Position;
+			ot.Write (bw, MajorVersion, MinorVersion);
+
+			//
+			// Sort the methods according to their tokens and update their index.
+			//
+			methods.Sort ();
+			for (int i = 0; i < methods.Count; i++)
+				methods [i].Index = i + 1;
+
+			//
+			// Write data sections.
+			//
+			ot.DataSectionOffset = (int) bw.BaseStream.Position;
+			foreach (SourceFileEntry source in sources)
+				source.WriteData (bw);
+			foreach (CompileUnitEntry comp_unit in comp_units)
+				comp_unit.WriteData (bw);
+			foreach (MethodEntry method in methods)
+				method.WriteData (this, bw);
+			ot.DataSectionSize = (int) bw.BaseStream.Position - ot.DataSectionOffset;
+
+			//
+			// Write the method index table.
+			//
+			ot.MethodTableOffset = (int) bw.BaseStream.Position;
+			for (int i = 0; i < methods.Count; i++) {
+				MethodEntry entry = methods [i];
+				entry.Write (bw);
+			}
+			ot.MethodTableSize = (int) bw.BaseStream.Position - ot.MethodTableOffset;
+
+			//
+			// Write source table.
+			//
+			ot.SourceTableOffset = (int) bw.BaseStream.Position;
+			for (int i = 0; i < sources.Count; i++) {
+				SourceFileEntry source = sources [i];
+				source.Write (bw);
+			}
+			ot.SourceTableSize = (int) bw.BaseStream.Position - ot.SourceTableOffset;
+
+			//
+			// Write compilation unit table.
+			//
+			ot.CompileUnitTableOffset = (int) bw.BaseStream.Position;
+			for (int i = 0; i < comp_units.Count; i++) {
+				CompileUnitEntry unit = comp_units [i];
+				unit.Write (bw);
+			}
+			ot.CompileUnitTableSize = (int) bw.BaseStream.Position - ot.CompileUnitTableOffset;
+
+			//
+			// Write anonymous scope table.
+			//
+			ot.AnonymousScopeCount = anonymous_scopes != null ? anonymous_scopes.Count : 0;
+			ot.AnonymousScopeTableOffset = (int) bw.BaseStream.Position;
+			if (anonymous_scopes != null) {
+				foreach (AnonymousScopeEntry scope in anonymous_scopes.Values)
+					scope.Write (bw);
+			}
+			ot.AnonymousScopeTableSize = (int) bw.BaseStream.Position - ot.AnonymousScopeTableOffset;
+
+			//
+			// Fixup offset table.
+			//
+			ot.TypeCount = last_type_index;
+			ot.MethodCount = methods.Count;
+			ot.SourceCount = sources.Count;
+			ot.CompileUnitCount = comp_units.Count;
+
+			//
+			// Write offset table.
+			//
+			ot.TotalFileSize = (int) bw.BaseStream.Position;
+			bw.Seek ((int) offset_table_offset, SeekOrigin.Begin);
+			ot.Write (bw, MajorVersion, MinorVersion);
+			bw.Seek (0, SeekOrigin.End);
+
+#if false
+			Console.WriteLine ("TOTAL: {0} line numbes, {1} bytes, extended {2} bytes, " +
+					   "{3} methods.", NumLineNumbers, LineNumberSize,
+					   ExtendedLineNumberSize, methods.Count);
+#endif
+		}
+
+		public void CreateSymbolFile (Guid guid, Stream fs)
+		{
+			if (reader != null)
+				throw new InvalidOperationException ();
+
+			Write (new MyBinaryWriter (fs), guid);
+		}
+
+		MyBinaryReader reader;
+		Dictionary<int, SourceFileEntry> source_file_hash;
+		Dictionary<int, CompileUnitEntry> compile_unit_hash;
+
+		List<MethodEntry> method_list;
+		Dictionary<int, MethodEntry> method_token_hash;
+		Dictionary<string, int> source_name_hash;
+
+		Guid guid;
+
+		MonoSymbolFile (Stream stream)
+		{
+			reader = new MyBinaryReader (stream);
+
+			try {
+				long magic = reader.ReadInt64 ();
+				int major_version = reader.ReadInt32 ();
+				int minor_version = reader.ReadInt32 ();
+
+				if (magic != OffsetTable.Magic)
+					throw new MonoSymbolFileException ("Symbol file is not a valid");
+				if (major_version != OffsetTable.MajorVersion)
+					throw new MonoSymbolFileException (
+						"Symbol file has version {0} but expected {1}", major_version, OffsetTable.MajorVersion);
+				if (minor_version != OffsetTable.MinorVersion)
+					throw new MonoSymbolFileException ("Symbol file has version {0}.{1} but expected {2}.{3}",
+						major_version, minor_version,
+						OffsetTable.MajorVersion, OffsetTable.MinorVersion);
+
+				MajorVersion = major_version;
+				MinorVersion = minor_version;
+				guid = new Guid (reader.ReadBytes (16));
+
+				ot = new OffsetTable (reader, major_version, minor_version);
+			} catch (Exception e) {
+				throw new MonoSymbolFileException ("Cannot read symbol file", e);
+			}
+
+			source_file_hash = new Dictionary<int, SourceFileEntry> ();
+			compile_unit_hash = new Dictionary<int, CompileUnitEntry> ();
+		}
+
+		public static MonoSymbolFile ReadSymbolFile (string mdbFilename)
+		{
+			return ReadSymbolFile (PclFileAccess.OpenFileStream (mdbFilename));
+		}
+
+		public static MonoSymbolFile ReadSymbolFile (string mdbFilename, Guid assemblyGuid)
+		{
+			var sf = ReadSymbolFile (mdbFilename);
+			if (assemblyGuid != sf.guid)
+				throw new MonoSymbolFileException ("Symbol file `{0}' does not match assembly", mdbFilename);
+
+			return sf;
+		}
+
+		public static MonoSymbolFile ReadSymbolFile (Stream stream)
+		{
+			return new MonoSymbolFile (stream);
+		}
+
+		public int CompileUnitCount {
+			get { return ot.CompileUnitCount; }
+		}
+
+		public int SourceCount {
+			get { return ot.SourceCount; }
+		}
+
+		public int MethodCount {
+			get { return ot.MethodCount; }
+		}
+
+		public int TypeCount {
+			get { return ot.TypeCount; }
+		}
+
+		public int AnonymousScopeCount {
+			get { return ot.AnonymousScopeCount; }
+		}
+
+		public int NamespaceCount {
+			get { return last_namespace_index; }
+		}
+
+		public Guid Guid {
+			get { return guid; }
+		}
+
+		public OffsetTable OffsetTable {
+			get { return ot; }
+		}
+
+		internal int LineNumberCount = 0;
+		internal int LocalCount = 0;
+		internal int StringSize = 0;
+
+		internal int LineNumberSize = 0;
+		internal int ExtendedLineNumberSize = 0;
+
+		public SourceFileEntry GetSourceFile (int index)
+		{
+			if ((index < 1) || (index > ot.SourceCount))
+				throw new ArgumentException ();
+			if (reader == null)
+				throw new InvalidOperationException ();
+
+			lock (this) {
+				SourceFileEntry source;
+				if (source_file_hash.TryGetValue (index, out source))
+					return source;
+
+				long old_pos = reader.BaseStream.Position;
+
+				reader.BaseStream.Position = ot.SourceTableOffset +
+					SourceFileEntry.Size * (index - 1);
+				source = new SourceFileEntry (this, reader);
+				source_file_hash.Add (index, source);
+
+				reader.BaseStream.Position = old_pos;
+				return source;
+			}
+		}
+
+		public SourceFileEntry[] Sources {
+			get {
+				if (reader == null)
+					throw new InvalidOperationException ();
+
+				SourceFileEntry[] retval = new SourceFileEntry [SourceCount];
+				for (int i = 0; i < SourceCount; i++)
+					retval [i] = GetSourceFile (i + 1);
+				return retval;
+			}
+		}
+
+		public CompileUnitEntry GetCompileUnit (int index)
+		{
+			if ((index < 1) || (index > ot.CompileUnitCount))
+				throw new ArgumentException ();
+			if (reader == null)
+				throw new InvalidOperationException ();
+
+			lock (this) {
+				CompileUnitEntry unit;
+				if (compile_unit_hash.TryGetValue (index, out unit))
+					return unit;
+
+				long old_pos = reader.BaseStream.Position;
+
+				reader.BaseStream.Position = ot.CompileUnitTableOffset +
+					CompileUnitEntry.Size * (index - 1);
+				unit = new CompileUnitEntry (this, reader);
+				compile_unit_hash.Add (index, unit);
+
+				reader.BaseStream.Position = old_pos;
+				return unit;
+			}
+		}
+
+		public CompileUnitEntry[] CompileUnits {
+			get {
+				if (reader == null)
+					throw new InvalidOperationException ();
+
+				CompileUnitEntry[] retval = new CompileUnitEntry [CompileUnitCount];
+				for (int i = 0; i < CompileUnitCount; i++)
+					retval [i] = GetCompileUnit (i + 1);
+				return retval;
+			}
+		}
+
+		void read_methods ()
+		{
+			lock (this) {
+				if (method_token_hash != null)
+					return;
+
+				method_token_hash = new Dictionary<int, MethodEntry> ();
+				method_list = new List<MethodEntry> ();
+
+				long old_pos = reader.BaseStream.Position;
+				reader.BaseStream.Position = ot.MethodTableOffset;
+
+				for (int i = 0; i < MethodCount; i++) {
+					MethodEntry entry = new MethodEntry (this, reader, i + 1);
+					method_token_hash.Add (entry.Token, entry);
+					method_list.Add (entry);
+				}
+
+				reader.BaseStream.Position = old_pos;
+			}
+		}
+
+		public MethodEntry GetMethodByToken (int token)
+		{
+			if (reader == null)
+				throw new InvalidOperationException ();
+
+			lock (this) {
+				read_methods ();
+				MethodEntry me;
+				method_token_hash.TryGetValue (token, out me);
+				return me;
+			}
+		}
+
+		public MethodEntry GetMethod (int index)
+		{
+			if ((index < 1) || (index > ot.MethodCount))
+				throw new ArgumentException ();
+			if (reader == null)
+				throw new InvalidOperationException ();
+
+			lock (this) {
+				read_methods ();
+				return method_list [index - 1];
+			}
+		}
+
+		public MethodEntry[] Methods {
+			get {
+				if (reader == null)
+					throw new InvalidOperationException ();
+
+				lock (this) {
+					read_methods ();
+					MethodEntry[] retval = new MethodEntry [MethodCount];
+					method_list.CopyTo (retval, 0);
+					return retval;
+				}
+			}
+		}
+
+		public int FindSource (string file_name)
+		{
+			if (reader == null)
+				throw new InvalidOperationException ();
+
+			lock (this) {
+				if (source_name_hash == null) {
+					source_name_hash = new Dictionary<string, int> ();
+
+					for (int i = 0; i < ot.SourceCount; i++) {
+						SourceFileEntry source = GetSourceFile (i + 1);
+						source_name_hash.Add (source.FileName, i);
+					}
+				}
+
+				int value;
+				if (!source_name_hash.TryGetValue (file_name, out value))
+					return -1;
+				return value;
+			}
+		}
+
+		public AnonymousScopeEntry GetAnonymousScope (int id)
+		{
+			if (reader == null)
+				throw new InvalidOperationException ();
+
+			AnonymousScopeEntry scope;
+			lock (this) {
+				if (anonymous_scopes != null) {
+					anonymous_scopes.TryGetValue (id, out scope);
+					return scope;
+				}
+
+				anonymous_scopes = new Dictionary<int, AnonymousScopeEntry> ();
+				reader.BaseStream.Position = ot.AnonymousScopeTableOffset;
+				for (int i = 0; i < ot.AnonymousScopeCount; i++) {
+					scope = new AnonymousScopeEntry (reader);
+					anonymous_scopes.Add (scope.ID, scope);
+				}
+
+				return anonymous_scopes [id];
+			}
+		}
+
+		internal MyBinaryReader BinaryReader {
+			get {
+				if (reader == null)
+					throw new InvalidOperationException ();
+
+				return reader;
+			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if (disposing) {
+				if (reader != null) {
+					reader.Dispose ();
+					reader = null;
+				}
+			}
+		}
+	}
+}

--- a/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MonoSymbolTable.cs
+++ b/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MonoSymbolTable.cs
@@ -1,0 +1,1436 @@
+//
+// Mono.CSharp.Debugger/MonoSymbolTable.cs
+//
+// Author:
+//   Martin Baulig (martin@ximian.com)
+//
+// (C) 2002 Ximian, Inc.  http://www.ximian.com
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+
+//
+// Parts which are actually written into the symbol file are marked with
+//
+//         #region This is actually written to the symbol file
+//         #endregion
+//
+// Please do not modify these regions without previously talking to me.
+//
+// All changes to the file format must be synchronized in several places:
+//
+// a) The fields in these regions (and their order) must match the actual
+//    contents of the symbol file.
+//
+//    This helps people to understand the symbol file format without reading
+//    too much source code, ie. you look at the appropriate region and then
+//    you know what's actually in the file.
+//
+//    It is also required to help me enforce b).
+//
+// b) The regions must be kept in sync with the unmanaged code in
+//    mono/metadata/debug-mono-symfile.h
+//
+// When making changes to the file format, you must also increase two version
+// numbers:
+//
+// i)  OffsetTable.Version in this file.
+// ii) MONO_SYMBOL_FILE_VERSION in mono/metadata/debug-mono-symfile.h
+//
+// After doing so, recompile everything, including the debugger.  Symbol files
+// with different versions are incompatible to each other and the debugger and
+// the runtime enfore this, so you need to recompile all your assemblies after
+// changing the file format.
+//
+
+
+namespace Mono.CompilerServices.SymbolWriter
+{
+	public class OffsetTable
+	{
+		public const int  MajorVersion = 50;
+		public const int  MinorVersion = 0;
+		public const long Magic        = 0x45e82623fd7fa614;
+
+		#region This is actually written to the symbol file
+		public int TotalFileSize;
+		public int DataSectionOffset;
+		public int DataSectionSize;
+		public int CompileUnitCount;
+		public int CompileUnitTableOffset;
+		public int CompileUnitTableSize;
+		public int SourceCount;
+		public int SourceTableOffset;
+		public int SourceTableSize;
+		public int MethodCount;
+		public int MethodTableOffset;
+		public int MethodTableSize;
+		public int TypeCount;
+		public int AnonymousScopeCount;
+		public int AnonymousScopeTableOffset;
+		public int AnonymousScopeTableSize;
+
+		[Flags]
+		public enum Flags
+		{
+			IsAspxSource		= 1,
+			WindowsFileNames	= 2
+		}
+
+		public Flags FileFlags;
+
+		public int LineNumberTable_LineBase = LineNumberTable.Default_LineBase;
+		public int LineNumberTable_LineRange = LineNumberTable.Default_LineRange;
+		public int LineNumberTable_OpcodeBase = LineNumberTable.Default_OpcodeBase;
+		#endregion
+
+		internal OffsetTable ()
+		{
+			if (Environment.NewLine == "\r\n")
+				FileFlags |= Flags.WindowsFileNames;
+		}
+
+		internal OffsetTable (BinaryReader reader, int major_version, int minor_version)
+		{
+			TotalFileSize = reader.ReadInt32 ();
+			DataSectionOffset = reader.ReadInt32 ();
+			DataSectionSize = reader.ReadInt32 ();
+			CompileUnitCount = reader.ReadInt32 ();
+			CompileUnitTableOffset = reader.ReadInt32 ();
+			CompileUnitTableSize = reader.ReadInt32 ();
+			SourceCount = reader.ReadInt32 ();
+			SourceTableOffset = reader.ReadInt32 ();
+			SourceTableSize = reader.ReadInt32 ();
+			MethodCount = reader.ReadInt32 ();
+			MethodTableOffset = reader.ReadInt32 ();
+			MethodTableSize = reader.ReadInt32 ();
+			TypeCount = reader.ReadInt32 ();
+
+			AnonymousScopeCount = reader.ReadInt32 ();
+			AnonymousScopeTableOffset = reader.ReadInt32 ();
+			AnonymousScopeTableSize = reader.ReadInt32 ();
+
+			LineNumberTable_LineBase = reader.ReadInt32 ();
+			LineNumberTable_LineRange = reader.ReadInt32 ();
+			LineNumberTable_OpcodeBase = reader.ReadInt32 ();
+
+			FileFlags = (Flags) reader.ReadInt32 ();
+		}
+
+		internal void Write (BinaryWriter bw, int major_version, int minor_version)
+		{
+			bw.Write (TotalFileSize);
+			bw.Write (DataSectionOffset);
+			bw.Write (DataSectionSize);
+			bw.Write (CompileUnitCount);
+			bw.Write (CompileUnitTableOffset);
+			bw.Write (CompileUnitTableSize);
+			bw.Write (SourceCount);
+			bw.Write (SourceTableOffset);
+			bw.Write (SourceTableSize);
+			bw.Write (MethodCount);
+			bw.Write (MethodTableOffset);
+			bw.Write (MethodTableSize);
+			bw.Write (TypeCount);
+
+			bw.Write (AnonymousScopeCount);
+			bw.Write (AnonymousScopeTableOffset);
+			bw.Write (AnonymousScopeTableSize);
+
+			bw.Write (LineNumberTable_LineBase);
+			bw.Write (LineNumberTable_LineRange);
+			bw.Write (LineNumberTable_OpcodeBase);
+
+			bw.Write ((int) FileFlags);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format (
+				"OffsetTable [{0} - {1}:{2} - {3}:{4}:{5} - {6}:{7}:{8} - {9}]",
+				TotalFileSize, DataSectionOffset, DataSectionSize, SourceCount,
+				SourceTableOffset, SourceTableSize, MethodCount, MethodTableOffset,
+				MethodTableSize, TypeCount);
+		}
+	}
+
+	public class LineNumberEntry
+	{
+		#region This is actually written to the symbol file
+		public readonly int Row;
+		public int Column;
+		public int EndRow, EndColumn;
+		public readonly int File;
+		public readonly int Offset;
+		public readonly bool IsHidden;	// Obsolete is never used
+		#endregion
+
+		public sealed class LocationComparer : IComparer<LineNumberEntry>
+		{
+			public static readonly LocationComparer Default = new LocationComparer ();
+
+			public int Compare (LineNumberEntry l1, LineNumberEntry l2)
+			{
+				return l1.Row == l2.Row ?
+					l1.Column.CompareTo (l2.Column) :
+					l1.Row.CompareTo (l2.Row);
+			}
+		}
+
+		public static readonly LineNumberEntry Null = new LineNumberEntry (0, 0, 0, 0);
+
+		public LineNumberEntry (int file, int row, int column, int offset)
+			: this (file, row, offset, column, false)
+		{
+		}
+
+		public LineNumberEntry (int file, int row, int offset)
+			: this (file, row, -1, offset, false)
+		{
+		}
+
+		public LineNumberEntry (int file, int row, int column, int offset, bool is_hidden)
+		: this (file, row, column, -1, -1, offset, is_hidden)
+		{
+		}
+
+		public LineNumberEntry (int file, int row, int column, int end_row, int end_column, int offset, bool is_hidden)
+		{
+			this.File = file;
+			this.Row = row;
+			this.Column = column;
+			this.EndRow = end_row;
+			this.EndColumn = end_column;
+			this.Offset = offset;
+			this.IsHidden = is_hidden;
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[Line {0}:{1,2}-{3,4}:{5}]", File, Row, Column, EndRow, EndColumn, Offset);
+		}
+	}
+
+	public class CodeBlockEntry
+	{
+		public int Index;
+		#region This is actually written to the symbol file
+		public int Parent;
+		public Type BlockType;
+		public int StartOffset;
+		public int EndOffset;
+		#endregion
+
+		public enum Type {
+			Lexical			= 1,
+			CompilerGenerated	= 2,
+			IteratorBody		= 3,
+			IteratorDispatcher	= 4
+		}
+
+		public CodeBlockEntry (int index, int parent, Type type, int start_offset)
+		{
+			this.Index = index;
+			this.Parent = parent;
+			this.BlockType = type;
+			this.StartOffset = start_offset;
+		}
+
+		internal CodeBlockEntry (int index, MyBinaryReader reader)
+		{
+			this.Index = index;
+			int type_flag = reader.ReadLeb128 ();
+			BlockType = (Type) (type_flag & 0x3f);
+			this.Parent = reader.ReadLeb128 ();
+			this.StartOffset = reader.ReadLeb128 ();
+			this.EndOffset = reader.ReadLeb128 ();
+
+			/* Reserved for future extensions. */
+			if ((type_flag & 0x40) != 0) {
+				int data_size = reader.ReadInt16 ();
+				reader.BaseStream.Position += data_size;
+			}				
+		}
+
+		public void Close (int end_offset)
+		{
+			this.EndOffset = end_offset;
+		}
+
+		internal void Write (MyBinaryWriter bw)
+		{
+			bw.WriteLeb128 ((int) BlockType);
+			bw.WriteLeb128 (Parent);
+			bw.WriteLeb128 (StartOffset);
+			bw.WriteLeb128 (EndOffset);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[CodeBlock {0}:{1}:{2}:{3}:{4}]",
+					      Index, Parent, BlockType, StartOffset, EndOffset);
+		}
+	}
+
+	public struct LocalVariableEntry
+	{
+		#region This is actually written to the symbol file
+		public readonly int Index;
+		public readonly string Name;
+		public readonly int BlockIndex;
+		#endregion
+
+		public LocalVariableEntry (int index, string name, int block)
+		{
+			this.Index = index;
+			this.Name = name;
+			this.BlockIndex = block;
+		}
+
+		internal LocalVariableEntry (MonoSymbolFile file, MyBinaryReader reader)
+		{
+			Index = reader.ReadLeb128 ();
+			Name = reader.ReadString ();
+			BlockIndex = reader.ReadLeb128 ();
+		}
+
+		internal void Write (MonoSymbolFile file, MyBinaryWriter bw)
+		{
+			bw.WriteLeb128 (Index);
+			bw.Write (Name);
+			bw.WriteLeb128 (BlockIndex);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[LocalVariable {0}:{1}:{2}]",
+					      Name, Index, BlockIndex - 1);
+		}
+	}
+
+	public struct CapturedVariable
+	{
+		#region This is actually written to the symbol file
+		public readonly string Name;
+		public readonly string CapturedName;
+		public readonly CapturedKind Kind;
+		#endregion
+
+		public enum CapturedKind : byte
+		{
+			Local,
+			Parameter,
+			This
+		}
+
+		public CapturedVariable (string name, string captured_name,
+					 CapturedKind kind)
+		{
+			this.Name = name;
+			this.CapturedName = captured_name;
+			this.Kind = kind;
+		}
+
+		internal CapturedVariable (MyBinaryReader reader)
+		{
+			Name = reader.ReadString ();
+			CapturedName = reader.ReadString ();
+			Kind = (CapturedKind) reader.ReadByte ();
+		}
+
+		internal void Write (MyBinaryWriter bw)
+		{
+			bw.Write (Name);
+			bw.Write (CapturedName);
+			bw.Write ((byte) Kind);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[CapturedVariable {0}:{1}:{2}]",
+					      Name, CapturedName, Kind);
+		}
+	}
+
+	public struct CapturedScope
+	{
+		#region This is actually written to the symbol file
+		public readonly int Scope;
+		public readonly string CapturedName;
+		#endregion
+
+		public CapturedScope (int scope, string captured_name)
+		{
+			this.Scope = scope;
+			this.CapturedName = captured_name;
+		}
+
+		internal CapturedScope (MyBinaryReader reader)
+		{
+			Scope = reader.ReadLeb128 ();
+			CapturedName = reader.ReadString ();
+		}
+
+		internal void Write (MyBinaryWriter bw)
+		{
+			bw.WriteLeb128 (Scope);
+			bw.Write (CapturedName);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[CapturedScope {0}:{1}]",
+					      Scope, CapturedName);
+		}
+	}
+
+	public struct ScopeVariable
+	{
+		#region This is actually written to the symbol file
+		public readonly int Scope;
+		public readonly int Index;
+		#endregion
+
+		public ScopeVariable (int scope, int index)
+		{
+			this.Scope = scope;
+			this.Index = index;
+		}
+
+		internal ScopeVariable (MyBinaryReader reader)
+		{
+			Scope = reader.ReadLeb128 ();
+			Index = reader.ReadLeb128 ();
+		}
+
+		internal void Write (MyBinaryWriter bw)
+		{
+			bw.WriteLeb128 (Scope);
+			bw.WriteLeb128 (Index);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[ScopeVariable {0}:{1}]", Scope, Index);
+		}
+	}
+
+	public class AnonymousScopeEntry
+	{
+		#region This is actually written to the symbol file
+		public readonly int ID;
+		#endregion
+
+		List<CapturedVariable> captured_vars = new List<CapturedVariable> ();
+		List<CapturedScope> captured_scopes = new List<CapturedScope> ();
+
+		public AnonymousScopeEntry (int id)
+		{
+			this.ID = id;
+		}
+
+		internal AnonymousScopeEntry (MyBinaryReader reader)
+		{
+			ID = reader.ReadLeb128 ();
+
+			int num_captured_vars = reader.ReadLeb128 ();
+			for (int i = 0; i < num_captured_vars; i++)
+				captured_vars.Add (new CapturedVariable (reader));
+
+			int num_captured_scopes = reader.ReadLeb128 ();
+			for (int i = 0; i < num_captured_scopes; i++)
+				captured_scopes.Add (new CapturedScope (reader));
+		}
+
+		internal void AddCapturedVariable (string name, string captured_name,
+						   CapturedVariable.CapturedKind kind)
+		{
+			captured_vars.Add (new CapturedVariable (name, captured_name, kind));
+		}
+
+		public CapturedVariable[] CapturedVariables {
+			get {
+				CapturedVariable[] retval = new CapturedVariable [captured_vars.Count];
+				captured_vars.CopyTo (retval, 0);
+				return retval;
+			}
+		}
+
+		internal void AddCapturedScope (int scope, string captured_name)
+		{
+			captured_scopes.Add (new CapturedScope (scope, captured_name));
+		}
+
+		public CapturedScope[] CapturedScopes {
+			get {
+				CapturedScope[] retval = new CapturedScope [captured_scopes.Count];
+				captured_scopes.CopyTo (retval, 0);
+				return retval;
+			}
+		}
+
+		internal void Write (MyBinaryWriter bw)
+		{
+			bw.WriteLeb128 (ID);
+
+			bw.WriteLeb128 (captured_vars.Count);
+			foreach (CapturedVariable cv in captured_vars)
+				cv.Write (bw);
+
+			bw.WriteLeb128 (captured_scopes.Count);
+			foreach (CapturedScope cs in captured_scopes)
+				cs.Write (bw);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[AnonymousScope {0}]", ID);
+		}
+	}
+
+	public class CompileUnitEntry : ICompileUnit
+	{
+		#region This is actually written to the symbol file
+		public readonly int Index;
+		int DataOffset;
+		#endregion
+
+		MonoSymbolFile file;
+		SourceFileEntry source;
+		List<SourceFileEntry> include_files;
+		List<NamespaceEntry> namespaces;
+
+		bool creating;
+
+		public static int Size {
+			get { return 8; }
+		}
+
+		CompileUnitEntry ICompileUnit.Entry {
+			get { return this; }
+		}
+
+		public CompileUnitEntry (MonoSymbolFile file, SourceFileEntry source)
+		{
+			this.file = file;
+			this.source = source;
+
+			this.Index = file.AddCompileUnit (this);
+
+			creating = true;
+			namespaces = new List<NamespaceEntry> ();
+		}
+
+		public void AddFile (SourceFileEntry file)
+		{
+			if (!creating)
+				throw new InvalidOperationException ();
+
+			if (include_files == null)
+				include_files = new List<SourceFileEntry> ();
+
+			include_files.Add (file);
+		}
+
+		public SourceFileEntry SourceFile {
+			get {
+				if (creating)
+					return source;
+
+				ReadData ();
+				return source;
+			}
+		}
+
+		public int DefineNamespace (string name, string[] using_clauses, int parent)
+		{
+			if (!creating)
+				throw new InvalidOperationException ();
+
+			int index = file.GetNextNamespaceIndex ();
+			NamespaceEntry ns = new NamespaceEntry (name, index, using_clauses, parent);
+			namespaces.Add (ns);
+			return index;
+		}
+
+		internal void WriteData (MyBinaryWriter bw)
+		{
+			DataOffset = (int) bw.BaseStream.Position;
+			bw.WriteLeb128 (source.Index);
+
+			int count_includes = include_files != null ? include_files.Count : 0;
+			bw.WriteLeb128 (count_includes);
+			if (include_files != null) {
+				foreach (SourceFileEntry entry in include_files)
+					bw.WriteLeb128 (entry.Index);
+			}
+
+			bw.WriteLeb128 (namespaces.Count);
+			foreach (NamespaceEntry ns in namespaces)
+				ns.Write (file, bw);
+		}
+
+		internal void Write (BinaryWriter bw)
+		{
+			bw.Write (Index);
+			bw.Write (DataOffset);
+		}
+
+		internal CompileUnitEntry (MonoSymbolFile file, MyBinaryReader reader)
+		{
+			this.file = file;
+
+			Index = reader.ReadInt32 ();
+			DataOffset = reader.ReadInt32 ();
+		}
+
+		public void ReadAll ()
+		{
+			ReadData ();
+		}
+
+		void ReadData ()
+		{
+			if (creating)
+				throw new InvalidOperationException ();
+
+			lock (file) {
+				if (namespaces != null)
+					return;
+
+				MyBinaryReader reader = file.BinaryReader;
+				int old_pos = (int) reader.BaseStream.Position;
+
+				reader.BaseStream.Position = DataOffset;
+
+				int source_idx = reader.ReadLeb128 ();
+				source = file.GetSourceFile (source_idx);
+
+				int count_includes = reader.ReadLeb128 ();
+				if (count_includes > 0) {
+					include_files = new List<SourceFileEntry> ();
+					for (int i = 0; i < count_includes; i++)
+						include_files.Add (file.GetSourceFile (reader.ReadLeb128 ()));
+				}
+
+				int count_ns = reader.ReadLeb128 ();
+				namespaces = new List<NamespaceEntry> ();
+				for (int i = 0; i < count_ns; i ++)
+					namespaces.Add (new NamespaceEntry (file, reader));
+
+				reader.BaseStream.Position = old_pos;
+			}
+		}
+
+		public NamespaceEntry[] Namespaces {
+			get {
+				ReadData ();
+				NamespaceEntry[] retval = new NamespaceEntry [namespaces.Count];
+				namespaces.CopyTo (retval, 0);
+				return retval;
+			}
+		}
+
+		public SourceFileEntry[] IncludeFiles {
+			get {
+				ReadData ();
+				if (include_files == null)
+					return new SourceFileEntry [0];
+
+				SourceFileEntry[] retval = new SourceFileEntry [include_files.Count];
+				include_files.CopyTo (retval, 0);
+				return retval;
+			}
+		}
+	}
+
+	public class SourceFileEntry
+	{
+		#region This is actually written to the symbol file
+		public readonly int Index;
+		int DataOffset;
+		#endregion
+
+		MonoSymbolFile file;
+		string file_name;
+		byte[] guid;
+		byte[] hash;
+		bool creating;
+		bool auto_generated;
+
+		public static int Size {
+			get { return 8; }
+		}
+
+		public SourceFileEntry (MonoSymbolFile file, string file_name)
+		{
+			this.file = file;
+			this.file_name = file_name;
+			this.Index = file.AddSource (this);
+
+			creating = true;
+		}
+
+		public SourceFileEntry (MonoSymbolFile file, string file_name, byte[] guid, byte[] checksum)
+			: this (file, file_name)
+		{
+			this.guid = guid;
+			this.hash = checksum;
+		}
+
+		public byte[] Checksum {
+			get {
+				return hash;
+			}
+		}
+
+		internal void WriteData (MyBinaryWriter bw)
+		{
+			DataOffset = (int) bw.BaseStream.Position;
+			bw.Write (file_name);
+
+			if (guid == null)
+				guid = new byte[16];
+
+			if (hash == null) {
+				try {
+					using (var fs = PclFileAccess.OpenFileStream (file_name)) {
+						var md5 = Microsoft.CodeAnalysis.CryptographicHashProvider.TryGetAlgorithm(System.Reflection.AssemblyHashAlgorithm.MD5);
+				        hash = md5.ComputeHash (fs);
+					}
+				} catch {
+					hash = new byte [16];
+				}
+			}
+
+			bw.Write (guid);
+			bw.Write (hash);
+			bw.Write ((byte) (auto_generated ? 1 : 0));
+		}
+
+		internal void Write (BinaryWriter bw)
+		{
+			bw.Write (Index);
+			bw.Write (DataOffset);
+		}
+
+		internal SourceFileEntry (MonoSymbolFile file, MyBinaryReader reader)
+		{
+			this.file = file;
+
+			Index = reader.ReadInt32 ();
+			DataOffset = reader.ReadInt32 ();
+
+			int old_pos = (int) reader.BaseStream.Position;
+			reader.BaseStream.Position = DataOffset;
+
+			file_name = reader.ReadString ();
+			guid = reader.ReadBytes (16);
+			hash = reader.ReadBytes (16);
+			auto_generated = reader.ReadByte () == 1;
+
+			reader.BaseStream.Position = old_pos;
+		}
+
+		public string FileName {
+			get { return file_name; }
+			set { file_name = value; }
+		}
+
+		public bool AutoGenerated {
+			get { return auto_generated; }
+		}
+
+		public void SetAutoGenerated ()
+		{
+			if (!creating)
+				throw new InvalidOperationException ();
+
+			auto_generated = true;
+			file.OffsetTable.FileFlags |= OffsetTable.Flags.IsAspxSource;
+		}
+
+		public bool CheckChecksum ()
+		{
+			try {
+				using (var fs = PclFileAccess.OpenFileStream (file_name)) {
+					var md5 = Microsoft.CodeAnalysis.CryptographicHashProvider.TryGetAlgorithm(System.Reflection.AssemblyHashAlgorithm.MD5);
+					byte[] data = md5.ComputeHash (fs);
+					for (int i = 0; i < 16; i++)
+						if (data [i] != hash [i])
+							return false;
+					return true;
+				}
+			} catch {
+				return false;
+			}
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("SourceFileEntry ({0}:{1})", Index, DataOffset);
+		}
+	}
+
+	public class LineNumberTable
+	{
+		protected LineNumberEntry[] _line_numbers;
+		public LineNumberEntry[] LineNumbers {
+			get { return _line_numbers; }
+		}
+
+		public readonly int LineBase;
+		public readonly int LineRange;
+		public readonly byte OpcodeBase;
+		public readonly int MaxAddressIncrement;
+
+#region Configurable constants
+		public const int Default_LineBase = -1;
+		public const int Default_LineRange = 8;
+		public const byte Default_OpcodeBase = 9;
+
+#endregion
+
+		public const byte DW_LNS_copy = 1;
+		public const byte DW_LNS_advance_pc = 2;
+		public const byte DW_LNS_advance_line = 3;
+		public const byte DW_LNS_set_file = 4;
+		public const byte DW_LNS_const_add_pc = 8;
+
+		public const byte DW_LNE_end_sequence = 1;
+
+		// MONO extensions.
+		public const byte DW_LNE_MONO_negate_is_hidden = 0x40;
+
+		internal const byte DW_LNE_MONO__extensions_start = 0x40;
+		internal const byte DW_LNE_MONO__extensions_end   = 0x7f;
+
+		protected LineNumberTable (MonoSymbolFile file)
+		{
+			this.LineBase = file.OffsetTable.LineNumberTable_LineBase;
+			this.LineRange = file.OffsetTable.LineNumberTable_LineRange;
+			this.OpcodeBase = (byte) file.OffsetTable.LineNumberTable_OpcodeBase;
+			this.MaxAddressIncrement = (255 - OpcodeBase) / LineRange;
+		}
+
+		internal LineNumberTable (MonoSymbolFile file, LineNumberEntry[] lines)
+			: this (file)
+		{
+			this._line_numbers = lines;
+		}
+
+		internal void Write (MonoSymbolFile file, MyBinaryWriter bw, bool hasColumnsInfo, bool hasEndInfo)
+		{
+			int start = (int) bw.BaseStream.Position;
+
+			bool last_is_hidden = false;
+			int last_line = 1, last_offset = 0, last_file = 1;
+			for (int i = 0; i < LineNumbers.Length; i++) {
+				int line_inc = LineNumbers [i].Row - last_line;
+				int offset_inc = LineNumbers [i].Offset - last_offset;
+
+				if (LineNumbers [i].File != last_file) {
+					bw.Write (DW_LNS_set_file);
+					bw.WriteLeb128 (LineNumbers [i].File);
+					last_file = LineNumbers [i].File;
+				}
+
+				if (LineNumbers [i].IsHidden != last_is_hidden) {
+					bw.Write ((byte) 0);
+					bw.Write ((byte) 1);
+					bw.Write (DW_LNE_MONO_negate_is_hidden);
+					last_is_hidden = LineNumbers [i].IsHidden;
+				}
+
+				if (offset_inc >= MaxAddressIncrement) {
+					if (offset_inc < 2 * MaxAddressIncrement) {
+						bw.Write (DW_LNS_const_add_pc);
+						offset_inc -= MaxAddressIncrement;
+					} else {
+						bw.Write (DW_LNS_advance_pc);
+						bw.WriteLeb128 (offset_inc);
+						offset_inc = 0;
+					}
+				}
+
+				if ((line_inc < LineBase) || (line_inc >= LineBase + LineRange)) {
+					bw.Write (DW_LNS_advance_line);
+					bw.WriteLeb128 (line_inc);
+					if (offset_inc != 0) {
+						bw.Write (DW_LNS_advance_pc);
+						bw.WriteLeb128 (offset_inc);
+					}
+					bw.Write (DW_LNS_copy);
+				} else {
+					byte opcode;
+					opcode = (byte) (line_inc - LineBase + (LineRange * offset_inc) +
+							 OpcodeBase);
+					bw.Write (opcode);
+				}
+
+				last_line = LineNumbers [i].Row;
+				last_offset = LineNumbers [i].Offset;
+			}
+
+			bw.Write ((byte) 0);
+			bw.Write ((byte) 1);
+			bw.Write (DW_LNE_end_sequence);
+
+			if (hasColumnsInfo) {
+				for (int i = 0; i < LineNumbers.Length; i++) {
+					var ln = LineNumbers [i];
+					if (ln.Row >= 0)
+						bw.WriteLeb128 (ln.Column);
+				}
+			}
+
+			if (hasEndInfo) {
+				for (int i = 0; i < LineNumbers.Length; i++) {
+					var ln = LineNumbers [i];
+					if (ln.EndRow == -1 || ln.EndColumn == -1 || ln.Row > ln.EndRow) {
+						bw.WriteLeb128 (0xffffff);
+					} else {
+						bw.WriteLeb128 (ln.EndRow - ln.Row);
+						bw.WriteLeb128 (ln.EndColumn);
+					}
+				}
+			}
+
+			file.ExtendedLineNumberSize += (int) bw.BaseStream.Position - start;
+		}
+
+		internal static LineNumberTable Read (MonoSymbolFile file, MyBinaryReader br, bool readColumnsInfo, bool readEndInfo)
+		{
+			LineNumberTable lnt = new LineNumberTable (file);
+			lnt.DoRead (file, br, readColumnsInfo, readEndInfo);
+			return lnt;
+		}
+
+		void DoRead (MonoSymbolFile file, MyBinaryReader br, bool includesColumns, bool includesEnds)
+		{
+			var lines = new List<LineNumberEntry> ();
+
+			bool is_hidden = false, modified = false;
+			int stm_line = 1, stm_offset = 0, stm_file = 1;
+			while (true) {
+				byte opcode = br.ReadByte ();
+
+				if (opcode == 0) {
+					byte size = br.ReadByte ();
+					long end_pos = br.BaseStream.Position + size;
+					opcode = br.ReadByte ();
+
+					if (opcode == DW_LNE_end_sequence) {
+						if (modified)
+							lines.Add (new LineNumberEntry (
+								stm_file, stm_line, -1, stm_offset, is_hidden));
+						break;
+					} else if (opcode == DW_LNE_MONO_negate_is_hidden) {
+						is_hidden = !is_hidden;
+						modified = true;
+					} else if ((opcode >= DW_LNE_MONO__extensions_start) &&
+						   (opcode <= DW_LNE_MONO__extensions_end)) {
+						; // reserved for future extensions
+					} else {
+						throw new MonoSymbolFileException ("Unknown extended opcode {0:x}", opcode);
+					}
+
+					br.BaseStream.Position = end_pos;
+					continue;
+				} else if (opcode < OpcodeBase) {
+					switch (opcode) {
+					case DW_LNS_copy:
+						lines.Add (new LineNumberEntry (
+							stm_file, stm_line, -1, stm_offset, is_hidden));
+						modified = false;
+						break;
+					case DW_LNS_advance_pc:
+						stm_offset += br.ReadLeb128 ();
+						modified = true;
+						break;
+					case DW_LNS_advance_line:
+						stm_line += br.ReadLeb128 ();
+						modified = true;
+						break;
+					case DW_LNS_set_file:
+						stm_file = br.ReadLeb128 ();
+						modified = true;
+						break;
+					case DW_LNS_const_add_pc:
+						stm_offset += MaxAddressIncrement;
+						modified = true;
+						break;
+					default:
+						throw new MonoSymbolFileException (
+							"Unknown standard opcode {0:x} in LNT",
+							opcode);
+					}
+				} else {
+					opcode -= OpcodeBase;
+
+					stm_offset += opcode / LineRange;
+					stm_line += LineBase + (opcode % LineRange);
+					lines.Add (new LineNumberEntry (
+						stm_file, stm_line, -1, stm_offset, is_hidden));
+					modified = false;
+				}
+			}
+
+			_line_numbers = lines.ToArray ();
+
+			if (includesColumns) {
+				for (int i = 0; i < _line_numbers.Length; ++i) {
+					var ln = _line_numbers[i];
+					if (ln.Row >= 0)
+						ln.Column = br.ReadLeb128 ();
+				}
+			}
+			if (includesEnds) {
+				for (int i = 0; i < _line_numbers.Length; ++i) {
+					var ln = _line_numbers[i];
+
+					int row = br.ReadLeb128 ();
+					if (row == 0xffffff) {
+						ln.EndRow = -1;
+						ln.EndColumn = -1;
+					} else {
+						ln.EndRow = ln.Row + row;
+						ln.EndColumn = br.ReadLeb128 ();
+					}
+				}
+			}
+		}
+
+		public bool GetMethodBounds (out LineNumberEntry start, out LineNumberEntry end)
+		{
+			if (_line_numbers.Length > 1) {
+				start = _line_numbers [0];
+				end = _line_numbers [_line_numbers.Length - 1];
+				return true;
+			}
+
+			start = LineNumberEntry.Null;
+			end = LineNumberEntry.Null;
+			return false;
+		}
+	}
+
+	public class MethodEntry : IComparable
+	{
+		#region This is actually written to the symbol file
+		public readonly int CompileUnitIndex;
+		public readonly int Token;
+		public readonly int NamespaceID;
+
+		int DataOffset;
+		int LocalVariableTableOffset;
+		int LineNumberTableOffset;
+		int CodeBlockTableOffset;
+		int ScopeVariableTableOffset;
+		int RealNameOffset;
+		Flags flags;
+		#endregion
+
+		int index;
+
+		public Flags MethodFlags {
+			get { return flags; }
+		}
+
+		public readonly CompileUnitEntry CompileUnit;
+
+		LocalVariableEntry[] locals;
+		CodeBlockEntry[] code_blocks;
+		ScopeVariable[] scope_vars;
+		LineNumberTable lnt;
+		string real_name;
+
+		public readonly MonoSymbolFile SymbolFile;
+
+		public int Index {
+			get { return index; }
+			set { index = value; }
+		}
+
+		[Flags]
+		public enum Flags
+		{
+			LocalNamesAmbiguous	= 1,
+			ColumnsInfoIncluded = 1 << 1,
+			EndInfoIncluded = 1 << 2
+		}
+
+		public const int Size = 12;
+
+		internal MethodEntry (MonoSymbolFile file, MyBinaryReader reader, int index)
+		{
+			this.SymbolFile = file;
+			this.index = index;
+
+			Token = reader.ReadInt32 ();
+			DataOffset = reader.ReadInt32 ();
+			LineNumberTableOffset = reader.ReadInt32 ();
+
+			long old_pos = reader.BaseStream.Position;
+			reader.BaseStream.Position = DataOffset;
+
+			CompileUnitIndex = reader.ReadLeb128 ();
+			LocalVariableTableOffset = reader.ReadLeb128 ();
+			NamespaceID = reader.ReadLeb128 ();
+
+			CodeBlockTableOffset = reader.ReadLeb128 ();
+			ScopeVariableTableOffset = reader.ReadLeb128 ();
+
+			RealNameOffset = reader.ReadLeb128 ();
+
+			flags = (Flags) reader.ReadLeb128 ();
+
+			reader.BaseStream.Position = old_pos;
+
+			CompileUnit = file.GetCompileUnit (CompileUnitIndex);
+		}
+
+		internal MethodEntry (MonoSymbolFile file, CompileUnitEntry comp_unit,
+				      int token, ScopeVariable[] scope_vars,
+				      LocalVariableEntry[] locals, LineNumberEntry[] lines,
+				      CodeBlockEntry[] code_blocks, string real_name,
+				      Flags flags, int namespace_id)
+		{
+			this.SymbolFile = file;
+			this.real_name = real_name;
+			this.locals = locals;
+			this.code_blocks = code_blocks;
+			this.scope_vars = scope_vars;
+			this.flags = flags;
+
+			index = -1;
+
+			Token = token;
+			CompileUnitIndex = comp_unit.Index;
+			CompileUnit = comp_unit;
+			NamespaceID = namespace_id;
+
+			CheckLineNumberTable (lines);
+			lnt = new LineNumberTable (file, lines);
+			file.NumLineNumbers += lines.Length;
+
+			int num_locals = locals != null ? locals.Length : 0;
+
+			if (num_locals <= 32) {
+				// Most of the time, the O(n^2) factor is actually
+				// less than the cost of allocating the hash table,
+				// 32 is a rough number obtained through some testing.
+				
+				for (int i = 0; i < num_locals; i ++) {
+					string nm = locals [i].Name;
+					
+					for (int j = i + 1; j < num_locals; j ++) {
+						if (locals [j].Name == nm) {
+							flags |= Flags.LocalNamesAmbiguous;
+							goto locals_check_done;
+						}
+					}
+				}
+			locals_check_done :
+				;
+			} else {
+				var local_names = new Dictionary<string, LocalVariableEntry> ();
+				foreach (LocalVariableEntry local in locals) {
+					if (local_names.ContainsKey (local.Name)) {
+						flags |= Flags.LocalNamesAmbiguous;
+						break;
+					}
+					local_names.Add (local.Name, local);
+				}
+			}
+		}
+		
+		static void CheckLineNumberTable (LineNumberEntry[] line_numbers)
+		{
+			int last_offset = -1;
+			int last_row = -1;
+
+			if (line_numbers == null)
+				return;
+			
+			for (int i = 0; i < line_numbers.Length; i++) {
+				LineNumberEntry line = line_numbers [i];
+
+				if (line.Equals (LineNumberEntry.Null))
+					throw new MonoSymbolFileException ();
+
+				if (line.Offset < last_offset)
+					throw new MonoSymbolFileException ();
+
+				if (line.Offset > last_offset) {
+					last_row = line.Row;
+					last_offset = line.Offset;
+				} else if (line.Row > last_row) {
+					last_row = line.Row;
+				}
+			}
+		}
+
+		internal void Write (MyBinaryWriter bw)
+		{
+			if ((index <= 0) || (DataOffset == 0))
+				throw new InvalidOperationException ();
+
+			bw.Write (Token);
+			bw.Write (DataOffset);
+			bw.Write (LineNumberTableOffset);
+		}
+
+		internal void WriteData (MonoSymbolFile file, MyBinaryWriter bw)
+		{
+			if (index <= 0)
+				throw new InvalidOperationException ();
+
+			LocalVariableTableOffset = (int) bw.BaseStream.Position;
+			int num_locals = locals != null ? locals.Length : 0;
+			bw.WriteLeb128 (num_locals);
+			for (int i = 0; i < num_locals; i++)
+				locals [i].Write (file, bw);
+			file.LocalCount += num_locals;
+
+			CodeBlockTableOffset = (int) bw.BaseStream.Position;
+			int num_code_blocks = code_blocks != null ? code_blocks.Length : 0;
+			bw.WriteLeb128 (num_code_blocks);
+			for (int i = 0; i < num_code_blocks; i++)
+				code_blocks [i].Write (bw);
+
+			ScopeVariableTableOffset = (int) bw.BaseStream.Position;
+			int num_scope_vars = scope_vars != null ? scope_vars.Length : 0;
+			bw.WriteLeb128 (num_scope_vars);
+			for (int i = 0; i < num_scope_vars; i++)
+				scope_vars [i].Write (bw);
+
+			if (real_name != null) {
+				RealNameOffset = (int) bw.BaseStream.Position;
+				bw.Write (real_name);
+			}
+
+			foreach (var lne in lnt.LineNumbers) {
+				if (lne.EndRow != -1 || lne.EndColumn != -1)
+					flags |= Flags.EndInfoIncluded;
+			}
+
+			LineNumberTableOffset = (int) bw.BaseStream.Position;
+			lnt.Write (file, bw, (flags & Flags.ColumnsInfoIncluded) != 0, (flags & Flags.EndInfoIncluded) != 0);
+
+			DataOffset = (int) bw.BaseStream.Position;
+
+			bw.WriteLeb128 (CompileUnitIndex);
+			bw.WriteLeb128 (LocalVariableTableOffset);
+			bw.WriteLeb128 (NamespaceID);
+
+			bw.WriteLeb128 (CodeBlockTableOffset);
+			bw.WriteLeb128 (ScopeVariableTableOffset);
+
+			bw.WriteLeb128 (RealNameOffset);
+			bw.WriteLeb128 ((int) flags);
+		}
+
+		public void ReadAll ()
+		{
+			GetLineNumberTable ();
+			GetLocals ();
+			GetCodeBlocks ();
+			GetScopeVariables ();
+			GetRealName ();
+		}
+
+		public LineNumberTable GetLineNumberTable ()
+		{
+			lock (SymbolFile) {
+				if (lnt != null)
+					return lnt;
+
+				if (LineNumberTableOffset == 0)
+					return null;
+
+				MyBinaryReader reader = SymbolFile.BinaryReader;
+				long old_pos = reader.BaseStream.Position;
+				reader.BaseStream.Position = LineNumberTableOffset;
+
+				lnt = LineNumberTable.Read (SymbolFile, reader, (flags & Flags.ColumnsInfoIncluded) != 0, (flags & Flags.EndInfoIncluded) != 0);
+
+				reader.BaseStream.Position = old_pos;
+				return lnt;
+			}
+		}
+
+		public LocalVariableEntry[] GetLocals ()
+		{
+			lock (SymbolFile) {
+				if (locals != null)
+					return locals;
+
+				if (LocalVariableTableOffset == 0)
+					return null;
+
+				MyBinaryReader reader = SymbolFile.BinaryReader;
+				long old_pos = reader.BaseStream.Position;
+				reader.BaseStream.Position = LocalVariableTableOffset;
+
+				int num_locals = reader.ReadLeb128 ();
+				locals = new LocalVariableEntry [num_locals];
+
+				for (int i = 0; i < num_locals; i++)
+					locals [i] = new LocalVariableEntry (SymbolFile, reader);
+
+				reader.BaseStream.Position = old_pos;
+				return locals;
+			}
+		}
+
+		public CodeBlockEntry[] GetCodeBlocks ()
+		{
+			lock (SymbolFile) {
+				if (code_blocks != null)
+					return code_blocks;
+
+				if (CodeBlockTableOffset == 0)
+					return null;
+
+				MyBinaryReader reader = SymbolFile.BinaryReader;
+				long old_pos = reader.BaseStream.Position;
+				reader.BaseStream.Position = CodeBlockTableOffset;
+
+				int num_code_blocks = reader.ReadLeb128 ();
+				code_blocks = new CodeBlockEntry [num_code_blocks];
+
+				for (int i = 0; i < num_code_blocks; i++)
+					code_blocks [i] = new CodeBlockEntry (i, reader);
+
+				reader.BaseStream.Position = old_pos;
+				return code_blocks;
+			}
+		}
+
+		public ScopeVariable[] GetScopeVariables ()
+		{
+			lock (SymbolFile) {
+				if (scope_vars != null)
+					return scope_vars;
+
+				if (ScopeVariableTableOffset == 0)
+					return null;
+
+				MyBinaryReader reader = SymbolFile.BinaryReader;
+				long old_pos = reader.BaseStream.Position;
+				reader.BaseStream.Position = ScopeVariableTableOffset;
+
+				int num_scope_vars = reader.ReadLeb128 ();
+				scope_vars = new ScopeVariable [num_scope_vars];
+
+				for (int i = 0; i < num_scope_vars; i++)
+					scope_vars [i] = new ScopeVariable (reader);
+
+				reader.BaseStream.Position = old_pos;
+				return scope_vars;
+			}
+		}
+
+		public string GetRealName ()
+		{
+			lock (SymbolFile) {
+				if (real_name != null)
+					return real_name;
+
+				if (RealNameOffset == 0)
+					return null;
+
+				real_name = SymbolFile.BinaryReader.ReadString (RealNameOffset);
+				return real_name;
+			}
+		}
+
+		public int CompareTo (object obj)
+		{
+			MethodEntry method = (MethodEntry) obj;
+
+			if (method.Token < Token)
+				return 1;
+			else if (method.Token > Token)
+				return -1;
+			else
+				return 0;
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[Method {0}:{1:x}:{2}:{3}]",
+					      index, Token, CompileUnitIndex, CompileUnit);
+		}
+	}
+
+	public struct NamespaceEntry
+	{
+		#region This is actually written to the symbol file
+		public readonly string Name;
+		public readonly int Index;
+		public readonly int Parent;
+		public readonly string[] UsingClauses;
+		#endregion
+
+		public NamespaceEntry (string name, int index, string[] using_clauses, int parent)
+		{
+			this.Name = name;
+			this.Index = index;
+			this.Parent = parent;
+			this.UsingClauses = using_clauses != null ? using_clauses : new string [0];
+		}
+
+		internal NamespaceEntry (MonoSymbolFile file, MyBinaryReader reader)
+		{
+			Name = reader.ReadString ();
+			Index = reader.ReadLeb128 ();
+			Parent = reader.ReadLeb128 ();
+
+			int count = reader.ReadLeb128 ();
+			UsingClauses = new string [count];
+			for (int i = 0; i < count; i++)
+				UsingClauses [i] = reader.ReadString ();
+		}
+
+		internal void Write (MonoSymbolFile file, MyBinaryWriter bw)
+		{
+			bw.Write (Name);
+			bw.WriteLeb128 (Index);
+			bw.WriteLeb128 (Parent);
+			bw.WriteLeb128 (UsingClauses.Length);
+			foreach (string uc in UsingClauses)
+				bw.Write (uc);
+		}
+
+		public override string ToString ()
+		{
+			return String.Format ("[Namespace {0}:{1}:{2}]", Name, Index, Parent);
+		}
+	}
+}

--- a/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MonoSymbolWriter.cs
+++ b/Src/Compilers/Core/Portable/PEWriter/MdbWriter/MonoSymbolWriter.cs
@@ -1,0 +1,268 @@
+//
+// Mono.CSharp.Debugger/MonoSymbolWriter.cs
+//
+// Author:
+//   Martin Baulig (martin@ximian.com)
+//
+// This is the default implementation of the System.Diagnostics.SymbolStore.ISymbolWriter
+// interface.
+//
+// (C) 2002 Ximian, Inc.  http://www.ximian.com
+//
+
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.IO;
+	
+namespace Mono.CompilerServices.SymbolWriter
+{
+	public class MonoSymbolWriter
+	{
+		List<SourceMethodBuilder> methods;
+		List<SourceFileEntry> sources;
+		List<CompileUnitEntry> comp_units;
+		protected readonly MonoSymbolFile file;
+		string filename;
+		
+		private SourceMethodBuilder current_method;
+		Stack<SourceMethodBuilder> current_method_stack = new Stack<SourceMethodBuilder> ();
+
+		Stream stream;
+
+		public MonoSymbolWriter (Stream stream)
+		{
+			this.stream = stream;
+			this.methods = new List<SourceMethodBuilder> ();
+			this.sources = new List<SourceFileEntry> ();
+			this.comp_units = new List<CompileUnitEntry> ();
+			this.file = new MonoSymbolFile ();
+		}
+
+		public MonoSymbolWriter (string filename)
+		{
+			this.methods = new List<SourceMethodBuilder> ();
+			this.sources = new List<SourceFileEntry> ();
+			this.comp_units = new List<CompileUnitEntry> ();
+			this.file = new MonoSymbolFile ();
+
+			this.filename = filename + ".mdb";
+		}
+
+		public MonoSymbolFile SymbolFile {
+			get { return file; }
+		}
+
+		public void CloseNamespace ()
+		{ }
+
+		public void DefineLocalVariable (int index, string name)
+		{
+			if (current_method == null)
+				return;
+
+			current_method.AddLocal (index, name);
+		}
+
+		public void DefineCapturedLocal (int scope_id, string name, string captured_name)
+		{
+			file.DefineCapturedVariable (scope_id, name, captured_name,
+						     CapturedVariable.CapturedKind.Local);
+		}
+
+		public void DefineCapturedParameter (int scope_id, string name, string captured_name)
+		{
+			file.DefineCapturedVariable (scope_id, name, captured_name,
+						     CapturedVariable.CapturedKind.Parameter);
+		}
+
+		public void DefineCapturedThis (int scope_id, string captured_name)
+		{
+			file.DefineCapturedVariable (scope_id, "this", captured_name,
+						     CapturedVariable.CapturedKind.This);
+		}
+
+		public void DefineCapturedScope (int scope_id, int id, string captured_name)
+		{
+			file.DefineCapturedScope (scope_id, id, captured_name);
+		}
+
+		public void DefineScopeVariable (int scope, int index)
+		{
+			if (current_method == null)
+				return;
+
+			current_method.AddScopeVariable (scope, index);
+		}
+
+		public void MarkSequencePoint (int offset, SourceFileEntry file, int line, int column,
+			bool isHidden)
+		{
+			if (current_method == null)
+				return;
+
+			current_method.MarkSequencePoint (offset, file, line, column, isHidden);
+		}
+
+		public void MarkSequencePoint (int offset, SourceFileEntry file, int line, int column,
+			int endLine, int endColumn, bool isHidden)
+		{
+			if (current_method == null)
+				return;
+
+			current_method.MarkSequencePoint (offset, file, line, column, endLine, endColumn, isHidden);
+		}
+
+		public SourceMethodBuilder OpenMethod (ICompileUnit file, int ns_id, IMethodDef method)
+		{
+			SourceMethodBuilder builder = new SourceMethodBuilder (file, ns_id, method);
+			current_method_stack.Push (current_method);
+			current_method = builder;
+			return builder;
+		}
+
+		public void SetMethodUnit (ICompileUnit file)
+		{
+			current_method._comp_unit = file;
+		}
+
+		public void CloseMethod ()
+		{
+			if (current_method._comp_unit != null)
+				methods.Add (current_method);
+			current_method = (SourceMethodBuilder) current_method_stack.Pop ();
+		}
+
+		public SourceFileEntry DefineDocument (string url)
+		{
+			SourceFileEntry entry = new SourceFileEntry (file, url);
+			sources.Add (entry);
+			return entry;
+		}
+
+		public SourceFileEntry DefineDocument (string url, byte[] guid, byte[] checksum)
+		{
+			SourceFileEntry entry = new SourceFileEntry (file, url, guid, checksum);
+			sources.Add (entry);
+			return entry;
+		}
+
+		public CompileUnitEntry DefineCompilationUnit (SourceFileEntry source)
+		{
+			CompileUnitEntry entry = new CompileUnitEntry (file, source);
+			comp_units.Add (entry);
+			return entry;
+		}
+
+		public int DefineNamespace (string name, CompileUnitEntry unit,
+					    string[] using_clauses, int parent)
+		{
+			if ((unit == null) || (using_clauses == null))
+				throw new NullReferenceException ();
+
+			return unit.DefineNamespace (name, using_clauses, parent);
+		}
+
+		public int OpenScope (int start_offset)
+		{
+			if (current_method == null)
+				return 0;
+
+			current_method.StartBlock (CodeBlockEntry.Type.Lexical, start_offset);
+			return 0;
+		}
+
+		public void CloseScope (int end_offset)
+		{
+			if (current_method == null)
+				return;
+
+			current_method.EndBlock (end_offset);
+		}
+
+		public void OpenCompilerGeneratedBlock (int start_offset)
+		{
+			if (current_method == null)
+				return;
+
+			current_method.StartBlock (CodeBlockEntry.Type.CompilerGenerated,
+						   start_offset);
+		}
+
+		public void CloseCompilerGeneratedBlock (int end_offset)
+		{
+			if (current_method == null)
+				return;
+
+			current_method.EndBlock (end_offset);
+		}
+
+		public void StartIteratorBody (int start_offset)
+		{
+			current_method.StartBlock (CodeBlockEntry.Type.IteratorBody,
+						   start_offset);
+		}
+
+		public void EndIteratorBody (int end_offset)
+		{
+			current_method.EndBlock (end_offset);
+		}
+
+		public void StartIteratorDispatcher (int start_offset)
+		{
+			current_method.StartBlock (CodeBlockEntry.Type.IteratorDispatcher,
+						   start_offset);
+		}
+
+		public void EndIteratorDispatcher (int end_offset)
+		{
+			current_method.EndBlock (end_offset);
+		}
+
+		public void DefineAnonymousScope (int id)
+		{
+			file.DefineAnonymousScope (id);
+		}
+
+		public void WriteSymbolFile (Guid guid)
+		{
+			foreach (SourceMethodBuilder method in methods)
+				method.DefineMethod (file);
+
+			if (stream != null) {
+				file.CreateSymbolFile (guid, stream);
+			} else {
+				try {
+					// We mmap the file, so unlink the previous version since it may be in use
+					PclFileAccess.Delete (filename);
+				} catch {
+					// We can safely ignore
+				}
+				using (var fs = PclFileAccess.CreateFileStream (filename)) {
+					file.CreateSymbolFile (guid, fs);
+				}
+			}
+		}
+	}
+}

--- a/Src/Compilers/Core/Portable/PEWriter/MdbWriter/PclFileAccess.cs
+++ b/Src/Compilers/Core/Portable/PEWriter/MdbWriter/PclFileAccess.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Mono.CompilerServices.SymbolWriter
+{
+	internal static class PclFileAccess
+	{
+		private static Lazy<Func<string, Stream>> lazyFileOpenStreamMethod = new Lazy<Func<string, Stream>> (() => {
+			Type file;
+			try {
+				// try contract name first:
+				file = Type.GetType ("System.IO.File, System.IO.FileStream, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
+			} catch {
+				file = null;
+			}
+
+			if (file == null) {
+				try {
+					// try corlib next:
+					file = typeof(object).GetTypeInfo ().Assembly.GetType ("System.IO.File");
+				} catch {
+					file = null;
+				}
+			}
+
+			try {
+				var openRead = file.GetTypeInfo ().GetDeclaredMethod ("OpenRead");
+				return (Func<string, Stream>)openRead.CreateDelegate (typeof(Func<string, Stream>));
+			} catch {
+				return null;
+			}
+		});
+
+		internal static Stream OpenFileStream (string path)
+		{
+			var factory = lazyFileOpenStreamMethod.Value;
+			if (factory == null) {
+				throw new PlatformNotSupportedException ();
+			}
+
+			Stream fileStream;
+			try {
+				fileStream = factory (path);
+			} catch (ArgumentException) {
+				throw;
+			} catch (IOException e) {
+				if (e.GetType ().Name == "DirectoryNotFoundException") {
+					throw new FileNotFoundException (e.Message, path, e);
+				}
+
+				throw;
+			} catch (Exception e) {
+				throw new IOException (e.Message, e);
+			}
+
+			return fileStream;
+		}
+
+		private static Lazy<Func<string, Stream>> lazyFileCreateStreamMethod = new Lazy<Func<string, Stream>> (() => {
+			Type file;
+			try {
+				// try contract name first:
+				file = Type.GetType ("System.IO.File, System.IO.FileStream, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
+			} catch {
+				file = null;
+			}
+
+			if (file == null) {
+				try {
+					// try corlib next:
+					file = typeof(object).GetTypeInfo ().Assembly.GetType ("System.IO.File");
+				} catch {
+					file = null;
+				}
+			}
+
+			try {
+				var openWrite = file.GetTypeInfo ().GetDeclaredMethod ("OpenWrite");
+				return (Func<string, Stream>)openWrite.CreateDelegate (typeof(Func<string, Stream>));
+			} catch {
+				return null;
+			}
+		});
+
+		internal static Stream CreateFileStream (string path)
+		{
+			var factory = lazyFileCreateStreamMethod.Value;
+			if (factory == null) {
+				throw new PlatformNotSupportedException ();
+			}
+
+			Stream fileStream;
+			try {
+				fileStream = factory (path);
+			} catch (ArgumentException) {
+				throw;
+			} catch (IOException e) {
+				if (e.GetType ().Name == "DirectoryNotFoundException") {
+					throw new FileNotFoundException (e.Message, path, e);
+				}
+
+				throw;
+			} catch (Exception e) {
+				throw new IOException (e.Message, e);
+			}
+
+			return fileStream;
+		}
+
+		private static Lazy<Action<string>> lazyFileDeleteMethod = new Lazy<Action<string>> (() => {
+			Type file;
+			try {
+				// try contract name first:
+				file = Type.GetType ("System.IO.File, System.IO.FileStream, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
+			} catch {
+				file = null;
+			}
+
+			if (file == null) {
+				try {
+					// try corlib next:
+					file = typeof(object).GetTypeInfo ().Assembly.GetType ("System.IO.File");
+				} catch {
+					file = null;
+				}
+			}
+
+			try {
+				var delete = file.GetTypeInfo ().GetDeclaredMethod ("Delete");
+				return (Action<string>)delete.CreateDelegate (typeof(Action<string>));
+			} catch {
+				return null;
+			}
+		});
+
+		internal static void Delete (string path)
+		{
+			var factory = lazyFileDeleteMethod.Value;
+			if (factory == null) {
+				throw new PlatformNotSupportedException ();
+			}
+
+			try {
+				factory (path);
+			} catch (ArgumentException) {
+				throw;
+			} catch (IOException e) {
+				if (e.GetType ().Name == "DirectoryNotFoundException") {
+					throw new FileNotFoundException (e.Message, path, e);
+				}
+
+				throw;
+			} catch (Exception e) {
+				throw new IOException (e.Message, e);
+			}
+		}
+	}
+}

--- a/Src/Compilers/Core/Portable/PEWriter/MdbWriter/SourceMethodBuilder.cs
+++ b/Src/Compilers/Core/Portable/PEWriter/MdbWriter/SourceMethodBuilder.cs
@@ -1,0 +1,190 @@
+//
+// SourceMethodBuilder.cs
+//
+// Authors:
+//   Martin Baulig (martin@ximian.com)
+//   Marek Safar (marek.safar@gmail.com)
+//
+// (C) 2002 Ximian, Inc.  http://www.ximian.com
+// Copyright (C) 2012 Xamarin Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+
+namespace Mono.CompilerServices.SymbolWriter
+{
+	public class SourceMethodBuilder
+	{
+		List<LocalVariableEntry> _locals;
+		List<CodeBlockEntry> _blocks;
+		List<ScopeVariable> _scope_vars;
+		Stack<CodeBlockEntry> _block_stack;
+		readonly List<LineNumberEntry> method_lines;
+
+		internal ICompileUnit _comp_unit;
+		readonly int ns_id;
+		readonly IMethodDef method;
+
+		public SourceMethodBuilder (ICompileUnit comp_unit)
+		{
+			this._comp_unit = comp_unit;
+			method_lines = new List<LineNumberEntry> ();
+		}
+
+		public SourceMethodBuilder (ICompileUnit comp_unit, int ns_id, IMethodDef method)
+			: this (comp_unit)
+		{
+			this.ns_id = ns_id;
+			this.method = method;
+		}
+
+		public void MarkSequencePoint (int offset, SourceFileEntry file, int line, int column, bool is_hidden)
+		{
+			MarkSequencePoint (offset, file, line, column, -1, -1, is_hidden);
+		}
+
+		public void MarkSequencePoint (int offset, SourceFileEntry file, int line, int column, int end_line, int end_column, bool is_hidden)
+		{
+			int file_idx = file != null ? file.Index : 0;
+			var lne = new LineNumberEntry (file_idx, line, column, end_line, end_column, offset, is_hidden);
+
+			if (method_lines.Count > 0) {
+				var prev = method_lines[method_lines.Count - 1];
+
+				//
+				// Same offset cannot be used for multiple lines
+				// 
+				if (prev.Offset == offset) {
+					//
+					// Use the new location because debugger will adjust
+					// the breakpoint to next line with sequence point
+					//
+					if (LineNumberEntry.LocationComparer.Default.Compare (lne, prev) > 0)
+						method_lines[method_lines.Count - 1] = lne;
+
+					return;
+				}
+			}
+
+			method_lines.Add (lne);
+		}
+
+		public void StartBlock (CodeBlockEntry.Type type, int start_offset)
+		{
+			if (_block_stack == null) {
+				_block_stack = new Stack<CodeBlockEntry> ();
+			}
+			
+			if (_blocks == null)
+				_blocks = new List<CodeBlockEntry> ();
+
+			int parent = CurrentBlock != null ? CurrentBlock.Index : -1;
+
+			CodeBlockEntry block = new CodeBlockEntry (
+				_blocks.Count + 1, parent, type, start_offset);
+
+			_block_stack.Push (block);
+			_blocks.Add (block);
+		}
+
+		public void EndBlock (int end_offset)
+		{
+			CodeBlockEntry block = (CodeBlockEntry) _block_stack.Pop ();
+			block.Close (end_offset);
+		}
+
+		public CodeBlockEntry[] Blocks {
+			get {
+				if (_blocks == null)
+					return new CodeBlockEntry [0];
+
+				CodeBlockEntry[] retval = new CodeBlockEntry [_blocks.Count];
+				_blocks.CopyTo (retval, 0);
+				return retval;
+			}
+		}
+
+		public CodeBlockEntry CurrentBlock {
+			get {
+				if ((_block_stack != null) && (_block_stack.Count > 0))
+					return (CodeBlockEntry) _block_stack.Peek ();
+				else
+					return null;
+			}
+		}
+
+		public LocalVariableEntry[] Locals {
+			get {
+				if (_locals == null)
+					return new LocalVariableEntry [0];
+				else {
+					return _locals.ToArray ();
+				}
+			}
+		}
+
+		public ICompileUnit SourceFile {
+			get {
+				return _comp_unit;
+			}
+		}
+
+		public void AddLocal (int index, string name)
+		{
+			if (_locals == null)
+				_locals = new List<LocalVariableEntry> ();
+			int block_idx = CurrentBlock != null ? CurrentBlock.Index : 0;
+			_locals.Add (new LocalVariableEntry (index, name, block_idx));
+		}
+
+		public ScopeVariable[] ScopeVariables {
+			get {
+				if (_scope_vars == null)
+					return new ScopeVariable [0];
+
+				return _scope_vars.ToArray ();
+			}
+		}
+
+		public void AddScopeVariable (int scope, int index)
+		{
+			if (_scope_vars == null)
+				_scope_vars = new List<ScopeVariable> ();
+			_scope_vars.Add (
+				new ScopeVariable (scope, index));
+		}
+
+		public void DefineMethod (MonoSymbolFile file)
+		{
+			DefineMethod (file, method.Token);
+		}
+
+		public void DefineMethod (MonoSymbolFile file, int token)
+		{
+			MethodEntry entry = new MethodEntry (
+				file, _comp_unit.Entry, token, ScopeVariables,
+				Locals, method_lines.ToArray (), Blocks, null, MethodEntry.Flags.ColumnsInfoIncluded, ns_id);
+
+			file.AddMethod (entry);
+		}
+	}
+}

--- a/Src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
+++ b/Src/Compilers/Core/Portable/PEWriter/PdbWriter.cs
@@ -53,7 +53,11 @@ namespace Microsoft.Cci
         {
             this.stream = new ComStreamWrapper(stream);
             this.fileName = fileName;
-            this.symWriterFactory = symWriterFactory;
+            if (Type.GetType ("Mono.Runtime") != null) {
+                this.symWriterFactory = new Func<object> (() => new Mono.CompilerServices.SymbolWriter.MdbWriter ());
+            } else {
+                this.symWriterFactory = symWriterFactory;
+            }
             CreateSequencePointBuffers(capacity: 64);
         }
 


### PR DESCRIPTION
First I will explain files...
- Files MonoSymbolFile.cs, MonoSymbolTable.cs, MonoSymbolWriter.cs and SourceMethodBuilder.cs are copy pastes from [mono/Mono.CompilerServices.SymbolWriter](https://github.com/mono/mono/tree/master/mcs/class/Mono.CompilerServices.SymbolWriter). There are minimal modifications like MD5 creation, opening files with PclFileAccess, added method SetMethodUnit to be able to set unit later because in ISymUnmanagedWriter2 it's not know at time of opening...
- PclFileAccess.cs file is workaround Pcl limitations to access file operations...
- PdbWriter.cs detect if we are on Mono and if we are use MdbWriter instead of pdb...
- MdbWriter.cs is implementation of ISymUnmanagedWriter2 which is basiclly just proxy between Roslyn .pdb emitting and MonoSymbolWriter.cs

Ok so... Lets list problems...
- MdbWriter is used automaticlly(always) when running on Mono and never on .Net... Could be improved with some flag like /debugformat:pdb/mdb but would require many changes in Roslyn files(problems with future merging)
- Use of reflection... "Initialize (object emitter, string filename, object ptrIStream, bool fullBuild)" call us with COMWrapped objects and so I didn't want to access stupid COM API so I just reflection extract .Net private field objects... I could probably achieve same thing without reflection(not 100% will investigate if this is problem)...
- I couldn't find way where I can access assembly GUID which must be same in MDB/PDB and assembly... I had to use reflection again to access "guidIndex" inside "writer" and fetch GUID with id 1.
- Roslyn send us Stream of PDB file and we don't use it... which creates empty(0 bytes) .pdb next to assembly and our .mdb file...
- See methods in "Used by Roslyn but not implemented" region... I'm mostly unsure about "UsingNamespace" and what is used for because some namespaces are in .mdb but Mono Runtime is not using those values...
- Also method GetDebugInfo returns 0 and I'm not sure if this is ok...
- Exception NotUsedInRoslynException is used to detect some changes if Roslyn start using some methods that we are not aware...

I tested this output with XS unit tests and all tests passed. I used a bit different version(one which removes "hidden"(0xfeefee lines) SequencePoints because MonoRuntime atm handles this seqPoints wrong(it should just ignore... will open PR on Runtime). I like to think this implementation is better then mcs.exe([Bug 25358](https://bugzilla.xamarin.com/show_bug.cgi?id=25358)) or pdb2mdb([Bug 25357](https://bugzilla.xamarin.com/show_bug.cgi?id=25357)) since this works :)
