### PR TITLE
Updated build instructions to mention mozroots.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ installation as a subdirectory of
 
 ## Restore packages
 
-	`mono src/.nuget/NuGet.exe restore src/Roslyn.sln`
+	mono src/.nuget/NuGet.exe restore src/Roslyn.sln
+
+On a fresh Mono install [that will fail with a certificate error](http://www.mono-project.com/docs/faq/security/).
+Run
+
+	mozroots --import --sync
+
+first to install the necessary root certificates for NuGet to be able to download files over HTTPS.
 
 ## Manual changes needed
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ installation as a subdirectory of
 
 	mono src/.nuget/NuGet.exe restore src/Roslyn.sln
 
-On a fresh Mono install [that will fail with a certificate error](http://www.mono-project.com/docs/faq/security/).
+If you just built Mono from source,
+[that will fail with a certificate error](http://www.mono-project.com/docs/faq/security/).
 Run
 
 	mozroots --import --sync


### PR DESCRIPTION
Added mention of mozroots to build instructions because NuGet's error messages did not lead very directly to that solution and it sounds like it's a required part of getting NuGet to work after building Mono from source. Admittedly, this is really a NuGet setup issue, not a Roslyn setup issue, but it's needed to compile Roslyn so I think it's reasonable to include here.
