### PR TITLE
Fix a build break by adding a parameter to an otherwise parameterless constructor.

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EncHoistedLocalInfo.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EncHoistedLocalInfo.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Emit
         public readonly LocalSlotDebugInfo SlotInfo;
         public readonly Cci.ITypeReference Type;
 
-        public EncHoistedLocalInfo()
+        public EncHoistedLocalInfo(bool ignored)
         {
             SlotInfo = new LocalSlotDebugInfo(SynthesizedLocalKind.EmitterTemp, LocalDebugId.None);
             Type = null;


### PR DESCRIPTION
This is the fix applied by the upstream repository, but merging from upstream is complex because there are heaps of other changes that I haven't got my head around.  This change at least allows you to build csc.exe using mono HEAD.
