### PR TITLE
Mono roslyn semantic tests 2.8.2

### DIFF
--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -79,13 +79,19 @@ single_test_name=${3:-}
 [[ "${single_test_name}" != "" ]] && was_argv_specified=1
 
 exit_code=0
-for test_path in "${unittest_dir}"/*/"${target_framework}" "${unittest_dir}"/*
+for test_path in "${unittest_dir}"/*
 do
-    file_names=("${test_path}"/*.UnitTests.dll)
-    file_name=${file_names[0]}
+    file_names=(${test_path}/${target_framework}/*.UnitTests.dll)
+    fallback_file_names=(${test_path}/*.UnitTests.dll)
 
-    if [ ! -f "${file_name}" ]; then
-        continue
+    if [ -f "${file_names[0]}" ]; then
+        file_name=${file_names[0]}
+    else
+        if [ -f "${fallback_file_names[0]}" ]; then
+            file_name=${fallback_file_names[0]}
+        else
+            continue
+        fi
     fi
 
     file_base_name=$(basename "${file_name}")

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -38,6 +38,16 @@ elif [[ "${runtime}" == "mono" ]]; then
         # GetSystemInfo is missing, and other problems
         # See https://github.com/mono/mono/issues/10678
         "Roslyn.Compilers.CSharp.WinRT.UnitTests.dll"
+        # Many test failures
+        "Roslyn.Compilers.UnitTests.dll"
+        # Multiple test failures
+        "Roslyn.Compilers.CSharp.CommandLine.UnitTests.dll"
+        # Multiple test failures
+        "Microsoft.Build.Tasks.CodeAnalysis.UnitTests.dll"
+        # Various failures related to PDBs, along with a runtime crash
+        "Roslyn.Compilers.CSharp.Emit.UnitTests.dll"
+        # Deadlocks or hangs for some reason
+        "Roslyn.Compilers.CompilerServer.UnitTests.dll"
     )
 else
     echo "Unknown runtime: ${runtime}"

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -106,7 +106,7 @@ do
         fi
     elif [[ "${runtime}" == "mono" ]]; then
         runner="mono --debug"
-        if [[ "${mono_excluded_assemblies[*]}" =~ "${file_base_name}" ]]
+        if [[ ("${mono_excluded_assemblies[*]}" =~ "${file_base_name}") && (! "${file_name}" =~ "${3:-}") ]]
         then
             echo "Skipping ${file_base_name}"
             continue

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -50,6 +50,9 @@ elif [[ "${runtime}" == "mono" ]]; then
         'Roslyn.Compilers.CompilerServer.UnitTests.dll'
         # Disabling on assumption
         'Roslyn.Compilers.VisualBasic.Emit.UnitTests.dll'
+        # A zillion test failures + crash
+        # See https://github.com/mono/mono/issues/10756
+        'Roslyn.Compilers.VisualBasic.Symbol.UnitTests.dll'
     )
 else
     echo "Unknown runtime: ${runtime}"

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -72,7 +72,7 @@ do
             continue
         fi
     elif [[ "${runtime}" == "mono" ]]; then
-        runner=mono
+        runner="mono --debug"
         if [[ "${file_name[@]}" == *'Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.dll' || "${file_name[@]}" == *'Roslyn.Compilers.CompilerServer.UnitTests.dll' || "${file_name[@]}" == *'Roslyn.Compilers.CSharp.Emit.UnitTests.dll' ]]
         then
             echo "Skipping ${file_name[@]}"

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -23,6 +23,11 @@ if [[ "${runtime}" == "dotnet" ]]; then
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/${target_framework}/xunit.console.dll
 elif [[ "${runtime}" == "mono" ]]; then
     target_framework=net461
+    file_list=(
+        "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll"
+        "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.dll"
+        "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.dll"
+        )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
 else
     echo "Unknown runtime: ${runtime}"

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -106,7 +106,7 @@ do
         fi
     elif [[ "${runtime}" == "mono" ]]; then
         runner="mono --debug"
-        if [[ ("${mono_excluded_assemblies[*]}" =~ "${file_base_name}") && (! "${file_name}" =~ "${3:-}") ]]
+        if [[ ("${mono_excluded_assemblies[*]}" =~ "${file_base_name}") || (("${3:-}" == "") && (! "${file_name}" =~ "${3:-}")) ]]
         then
             echo "Skipping ${file_base_name}"
             continue

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -25,29 +25,31 @@ elif [[ "${runtime}" == "mono" ]]; then
     target_framework=net461
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
     mono_excluded_assemblies=(
-        "Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.dll"
-        "Roslyn.Compilers.CompilerServer.UnitTests.dll"
+        'Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.dll'
+        'Roslyn.Compilers.CompilerServer.UnitTests.dll'
         # Missing mscoree.dll, other problems
-        "Roslyn.Compilers.CSharp.Emit.UnitTests.dll"
+        'Roslyn.Compilers.CSharp.Emit.UnitTests.dll'
         # Omitted because we appear to be missing things necessary to compile vb.net.
         # See https://github.com/mono/mono/issues/10679
-        "Roslyn.Compilers.VisualBasic.CommandLine.UnitTests.dll"
-        "Roslyn.Compilers.VisualBasic.Semantic.UnitTests.dll"
+        'Roslyn.Compilers.VisualBasic.CommandLine.UnitTests.dll'
+        'Roslyn.Compilers.VisualBasic.Semantic.UnitTests.dll'
         # PortablePdb and lots of other problems
-        "Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests.dll"
+        'Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests.dll'
         # GetSystemInfo is missing, and other problems
         # See https://github.com/mono/mono/issues/10678
-        "Roslyn.Compilers.CSharp.WinRT.UnitTests.dll"
+        'Roslyn.Compilers.CSharp.WinRT.UnitTests.dll'
         # Many test failures
-        "Roslyn.Compilers.UnitTests.dll"
+        'Roslyn.Compilers.UnitTests.dll'
         # Multiple test failures
-        "Roslyn.Compilers.CSharp.CommandLine.UnitTests.dll"
+        'Roslyn.Compilers.CSharp.CommandLine.UnitTests.dll'
         # Multiple test failures
-        "Microsoft.Build.Tasks.CodeAnalysis.UnitTests.dll"
+        'Microsoft.Build.Tasks.CodeAnalysis.UnitTests.dll'
         # Various failures related to PDBs, along with a runtime crash
-        "Roslyn.Compilers.CSharp.Emit.UnitTests.dll"
+        'Roslyn.Compilers.CSharp.Emit.UnitTests.dll'
         # Deadlocks or hangs for some reason
-        "Roslyn.Compilers.CompilerServer.UnitTests.dll"
+        'Roslyn.Compilers.CompilerServer.UnitTests.dll'
+        # Disabling on assumption
+        'Roslyn.Compilers.VisualBasic.Emit.UnitTests.dll'
     )
 else
     echo "Unknown runtime: ${runtime}"
@@ -95,22 +97,23 @@ do
         continue
     fi
 
-    echo Running "${runtime} ${file_name[@]}"
     if [[ "${runtime}" == "dotnet" ]]; then
         runner="dotnet exec --depsfile ${deps_json} --runtimeconfig ${runtimeconfig_json}"
         if [[ "${file_name[@]}" == *'Roslyn.Compilers.CSharp.Emit.UnitTests.dll' ]]
         then
-            echo "Skipping ${file_name[@]}"
+            echo "Skipping ${file_base_name}"
             continue
         fi
     elif [[ "${runtime}" == "mono" ]]; then
         runner="mono --debug"
-        if [[ $mono_excluded_assemblies =~ ${file_name[@]} ]]
+        if [[ "${mono_excluded_assemblies[*]}" =~ "${file_base_name}" ]]
         then
-            echo "Skipping ${file_name[@]}"
+            echo "Skipping ${file_base_name}"
             continue
         fi
     fi
+    
+    echo Running "${runtime} ${file_base_name}"
     if ${runner} "${xunit_console}" "${file_name[@]}" -xml "${log_file}"
     then
         echo "Assembly ${file_name[@]} passed"

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -23,11 +23,6 @@ if [[ "${runtime}" == "dotnet" ]]; then
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/${target_framework}/xunit.console.dll
 elif [[ "${runtime}" == "mono" ]]; then
     target_framework=net461
-    file_list=(
-        "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.dll"
-        "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.dll"
-        "${unittest_dir}/Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests/net46/Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.dll"
-        )
     xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
 else
     echo "Unknown runtime: ${runtime}"
@@ -53,7 +48,7 @@ echo "Using ${xunit_console}"
 mkdir -p "${log_dir}"
 
 exit_code=0
-for test_path in "${unittest_dir}"/*/"${target_framework}"
+for test_path in "${unittest_dir}"/*/"${target_framework}" "${unittest_dir}"/*
 do
     file_name=( "${test_path}"/*.UnitTests.dll )
     log_file="${log_dir}"/"$(basename "${file_name%.*}.xml")"
@@ -62,7 +57,7 @@ do
 
     # If the user specifies a test on the command line, only run that one
     # "${3:-}" => take second arg, empty string if unset
-    if [[ ("${3:-}" != "") && (! "${file_name}" =~ "${2:-}") ]]
+    if [[ ("${3:-}" != "") && (! "${file_name}" =~ "${3:-}") ]]
     then
         echo "Skipping ${file_name}"
         continue

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
@@ -2761,7 +2761,8 @@ class Repro
             CompileAndVerify(comp, expectedOutput: "42");
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void DynamicResultTypeCustomAwaiter()
         {
             const string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -3426,7 +3426,8 @@ class Test
             Assert.Equal("void Test.Goo<dynamic>(System.Action<dynamic> action, System.Collections.Generic.IEnumerable<dynamic> source)", model.GetSymbolInfo(node).Symbol.ToTestDisplayString());
         }
 
-        [Fact, WorkItem(875140, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875140")]
+        [ClrOnlyFact, WorkItem(875140, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875140")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void Bug875140_01()
         {
             string source = @"
@@ -3453,7 +3454,8 @@ class Program
             Assert.Equal("System.Object Program.Goo<System.Object>(System.Action<System.Object, System.Object> x)", model.GetSymbolInfo(node).Symbol.ToTestDisplayString());
         }
 
-        [Fact, WorkItem(875140, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875140")]
+        [ClrOnlyFact, WorkItem(875140, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875140")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void Bug875140_02()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -2881,7 +2881,8 @@ class Program
         }
 
         [WorkItem(11387, "https://github.com/dotnet/roslyn/issues/11387")]
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void StringNotIEnumerable()
         {
             var source1 =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -2483,8 +2483,14 @@ class Test
         [InlineData("false", "System.Boolean", 1)]
         [InlineData("E.A", "E", 4)]
         [InlineData("new S { a = 1, b = 2, c = 3 }", "S", 12)]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void UnmanagedConstraints_PointerOperations_SimpleTypes(string arg, string type, int size)
         {
+            if (MonoHelpers.IsRunningOnMono()) {
+                Console.Error.WriteLine("UnmanagedConstraints_PointerOperations_SimpleTypes [SKIP]");
+                return;
+            }
+
             CompileAndVerify(@"
 enum E
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -2532,7 +2532,8 @@ unsafe class Test
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void UnmanagedConstraints_InterfaceMethod()
         {
             CompileAndVerify(@"
@@ -3008,7 +3009,8 @@ public class Test
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "IsEnum<Wrapper<string>.S>").WithArguments("Test.IsEnum<T>()", "System.Enum", "T", "Wrapper<string>.S").WithLocation(38, 9));
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void UnmanagedConstraints_PointerInsideStruct()
         {
             CompileAndVerify(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -969,7 +969,8 @@ class Program {
             );
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void SillyCoreLib01()
         {
             var text =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MultiDimensionalArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MultiDimensionalArrayTests.cs
@@ -1575,8 +1575,9 @@ Overriden 16
 ");
         }
 
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [ClrOnlyFact]
         [WorkItem(4958, "https://github.com/dotnet/roslyn/issues/4958")]
+        [WorkItem(10757 ,"https://github.com/mono/mono/issues/10757")]
         public void ArraysOfRank1_InAttributes()
         {
             var ilSource = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MultiDimensionalArrayTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MultiDimensionalArrayTests.cs
@@ -279,7 +279,8 @@ Diagnostic(ErrorCode.ERR_ArrayInitializerExpected, "null")
 ";
 
         [WorkItem(126766, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/126766"), WorkItem(4924, "https://github.com/dotnet/roslyn/issues/4924")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [WorkItem(10755, "https://github.com/mono/mono/issues/10755")]
+        [ClrOnlyFact]
         public void ArraysOfRank1_GetElement()
         {
             var source =
@@ -312,7 +313,8 @@ Diagnostic(ErrorCode.ERR_ArrayInitializerExpected, "null")
         }
 
         [WorkItem(126766, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/126766"), WorkItem(4924, "https://github.com/dotnet/roslyn/issues/4924")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [WorkItem(10755, "https://github.com/mono/mono/issues/10755")]
+        [ClrOnlyFact]
         public void ArraysOfRank1_SetElement()
         {
             var source =
@@ -355,7 +357,8 @@ Test2
         }
 
         [WorkItem(126766, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/126766"), WorkItem(4924, "https://github.com/dotnet/roslyn/issues/4924")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [WorkItem(10755, "https://github.com/mono/mono/issues/10755")]
+        [ClrOnlyFact]
         public void ArraysOfRank1_ElementAddress()
         {
             var source =
@@ -571,7 +574,8 @@ Test2
         }
 
         [WorkItem(126766, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/126766"), WorkItem(4924, "https://github.com/dotnet/roslyn/issues/4924")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [WorkItem(10755, "https://github.com/mono/mono/issues/10755")]
+        [ClrOnlyFact]
         public void ArraysOfRank1_TypeArgumentInference02()
         {
             var source =
@@ -604,7 +608,8 @@ System.Double
         }
 
         [WorkItem(126766, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/126766"), WorkItem(4924, "https://github.com/dotnet/roslyn/issues/4924")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [WorkItem(10755, "https://github.com/mono/mono/issues/10755")]
+        [ClrOnlyFact]
         public void ArraysOfRank1_ForEach()
         {
             var source =
@@ -661,7 +666,8 @@ System.Double
         }
 
         [WorkItem(126766, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/126766"), WorkItem(4924, "https://github.com/dotnet/roslyn/issues/4924")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [WorkItem(10755, "https://github.com/mono/mono/issues/10755")]
+        [ClrOnlyFact]
         public void ArraysOfRank1_Length()
         {
             var source =
@@ -693,7 +699,8 @@ System.Double
         }
 
         [WorkItem(126766, "https://devdiv.visualstudio.com:443/defaultcollection/DevDiv/_workitems/edit/126766"), WorkItem(4924, "https://github.com/dotnet/roslyn/issues/4924")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        [WorkItem(10755, "https://github.com/mono/mono/issues/10755")]
+        [ClrOnlyFact]
         public void ArraysOfRank1_LongLength()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -741,7 +741,8 @@ Diagnostic(ErrorCode.ERR_BadNamedArgument, "y").WithArguments("PartialMethod", "
                 );
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void TestNamedAndOptionalParametersUnsafe()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableTests.cs
@@ -107,7 +107,8 @@ class C
                 );
         }
 
-        [Fact, WorkItem(543954, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543954")]
+        [ClrOnlyFact, WorkItem(543954, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543954")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void TestLiftedIncrementOperatorBreakingChanges02()
         {
             // Now here we have a case where the compilation *should* succeed, and does, but 
@@ -174,7 +175,8 @@ class C
             verifier = CompileAndVerify(source: source3, expectedOutput: "1", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
         }
 
-        [Fact, WorkItem(543954, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543954")]
+        [ClrOnlyFact, WorkItem(543954, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543954")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void TestLiftedIncrementOperatorBreakingChanges03()
         {
             // Let's in fact verify that this works correctly for all possible conversions to built-in types:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -12555,7 +12555,7 @@ public class X
             VerifyModelForOutVarWithoutDataFlow(model, y4Decl, y4Ref);
         }
 
-        [ConditionalFact(typeof(DesktopClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/28026")]
+        [ConditionalFact(typeof(DesktopClrOnly))]
         [WorkItem(10562, "https://github.com/mono/mono/issues/10562")]
         public void Query_01()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -12555,7 +12555,8 @@ public class X
             VerifyModelForOutVarWithoutDataFlow(model, y4Decl, y4Ref);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DesktopClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/28026")]
+        [WorkItem(10562, "https://github.com/mono/mono/issues/10562")]
         public void Query_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -6021,7 +6021,8 @@ public unsafe class X
             VerifyModelForOutVarDuplicateInSameScope(model, x4Decl[1]);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void Fixed_01()
         {
             var source =
@@ -6055,7 +6056,8 @@ public unsafe class X
 fixed");
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void Fixed_02()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -2579,7 +2579,8 @@ class Test
             CreateCompilation(source).VerifyDiagnostics();
         }
 
-        [Fact, WorkItem(530747, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530747")]
+        [ClrOnlyFact, WorkItem(530747, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530747")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void RefOmittedComCall_Unsafe()
         {
             // Native compiler generates invalid IL for ref omitted argument of pointer type, while Roslyn generates correct IL.
@@ -11050,7 +11051,8 @@ class Program
             CompileAndVerify(code, expectedOutput: @"2");
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void MethodGroupConversionIn2Overloaded()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -782,7 +782,8 @@ True");
             VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DesktopClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/28026")]
+        [WorkItem(10562, "https://github.com/mono/mono/issues/10562")]
         public void Query_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -782,7 +782,7 @@ True");
             VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
         }
 
-        [ConditionalFact(typeof(DesktopClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/28026")]
+        [ConditionalFact(typeof(DesktopClrOnly))]
         [WorkItem(10562, "https://github.com/mono/mono/issues/10562")]
         public void Query_01()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -2555,7 +2555,8 @@ public class X
             VerifyModelForDeclarationPattern(model, x1Decl[1], x1Ref[1]);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void Fixed_01()
         {
             var source =
@@ -6384,7 +6385,8 @@ internal class Program
             var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
 
-        [Fact, WorkItem(23100, "https://github.com/dotnet/roslyn/issues/23100")]
+        [ClrOnlyFact, WorkItem(23100, "https://github.com/dotnet/roslyn/issues/23100")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void TestArrayOfPointer()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -21249,7 +21249,7 @@ public class Test
                 Diagnostic(ErrorCode.WRN_MissingXMLComment, "Main").WithArguments("Test.Main()"));
         }
 
-        [ConditionalFact(typeof(DesktopClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/18610")]
+        [ConditionalFact(typeof(DesktopClrOnly))]
         [WorkItem(10567, "https://github.com/mono/mono/issues/10567")]
         public void CS1592WRN_XMLParseIncludeError()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7206,7 +7206,8 @@ class MyDerived : MyClass
                 );
         }
 
-        [Fact, WorkItem(990, "https://github.com/dotnet/roslyn/issues/990")]
+        [ClrOnlyFact, WorkItem(990, "https://github.com/dotnet/roslyn/issues/990")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void WriteOfReadonlyStaticMemberOfAnotherInstantiation02()
         {
             var text =
@@ -15493,7 +15494,8 @@ class Test
                  );
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void CS1666ERR_FixedBufferNotFixed()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -21249,7 +21249,8 @@ public class Test
                 Diagnostic(ErrorCode.WRN_MissingXMLComment, "Main").WithArguments("Test.Main()"));
         }
 
-        [ClrOnlyFact]
+        [ConditionalFact(typeof(DesktopClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/18610")]
+        [WorkItem(10567, "https://github.com/mono/mono/issues/10567")]
         public void CS1592WRN_XMLParseIncludeError()
         {
             var xmlFile = Temp.CreateFile(extension: ".xml").WriteAllText("&");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -399,7 +399,8 @@ unsafe class Test
             Assert.Equal(Conversion.Identity, element0Info.ImplicitConversion);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void TestFor_Pointer()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -8200,8 +8200,9 @@ class C
             CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         [WorkItem(547030, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547030")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void FixedBuffersUsageScenarioInRange()
         {
             var text = @"
@@ -8312,8 +8313,9 @@ class Program
 ");
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         [WorkItem(547030, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547030")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void FixedBuffersUsagescenarioOutOfRange()
         {
             // This should work as no range checking for unsafe code.
@@ -8470,8 +8472,9 @@ unsafe struct S
             }
         }
 
-        [Fact()]
+        [ClrOnlyFact]
         [WorkItem(547030, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547030")]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void FixedBufferUsageDifferentAssemblies()
         {
             // Ensure fixed buffers work as expected when fixed buffer is created in different assembly to where it is consumed.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -8429,7 +8429,8 @@ class Program
 }");
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10752, "https://github.com/mono/mono/issues/10752")]
         public void FixedBufferUsageWith_this()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -215,7 +215,8 @@ class Module1
             CompileAndVerify(compilation, expectedOutput: "Test");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
+        [WorkItem(10565, "https://github.com/mono/mono/issues/10565")]
         [WorkItem(4163, "https://github.com/dotnet/roslyn/issues/4163")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
         public void ConcatModifiers_02()
@@ -296,7 +297,8 @@ class CL3
             CompileAndVerify(compilation, expectedOutput: "Overridden");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
+        [WorkItem(10565, "https://github.com/mono/mono/issues/10565")]
         [WorkItem(4163, "https://github.com/dotnet/roslyn/issues/4163")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
         public void ConcatModifiersAndByRef_01()
@@ -369,7 +371,8 @@ class CL3
             CompileAndVerify(compilation, expectedOutput: "Overridden");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
+        [WorkItem(10565, "https://github.com/mono/mono/issues/10565")]
         [WorkItem(4163, "https://github.com/dotnet/roslyn/issues/4163")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
         public void ConcatModifiersAndByRef_02()
@@ -515,7 +518,8 @@ class CL3
             CompileAndVerify(compilation, expectedOutput: "Overridden");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
+        [WorkItem(10565, "https://github.com/mono/mono/issues/10565")]
         [WorkItem(4163, "https://github.com/dotnet/roslyn/issues/4163")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
         public void ConcatModifiersAndByRef_04()
@@ -589,7 +593,8 @@ class CL3
             CompileAndVerify(compilation, expectedOutput: "Overridden");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
+        [WorkItem(10565, "https://github.com/mono/mono/issues/10565")]
         [WorkItem(8948, "https://github.com/dotnet/roslyn/issues/8948")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
         public void ConcatModifiersAndByRefReturn_01()
@@ -700,7 +705,8 @@ class CL3
 Overridden P");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
+        [WorkItem(10565, "https://github.com/mono/mono/issues/10565")]
         [WorkItem(8948, "https://github.com/dotnet/roslyn/issues/8948")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
         public void ConcatModifiersAndByRefReturn_02()
@@ -920,7 +926,8 @@ class CL3
 Overridden P");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
+        [WorkItem(10565, "https://github.com/mono/mono/issues/10565")]
         [WorkItem(8948, "https://github.com/dotnet/roslyn/issues/8948")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
         public void ConcatModifiersAndByRefReturn_04()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -1125,9 +1125,10 @@ CL3.P
 ");
         }
 
-        [ConditionalFact(typeof(DesktopOnly))]
+        [ConditionalFact(typeof(DesktopClrOnly))]
         [WorkItem(4163, "https://github.com/dotnet/roslyn/issues/4163")]
         [WorkItem(18411, "https://github.com/dotnet/roslyn/issues/18411")]
+        [WorkItem(10564, "https://github.com/mono/mono/issues/10564")]
         public void ConcatModifiers_03()
         {
             var ilSource = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -19773,7 +19773,9 @@ namespace A
                 Diagnostic(ErrorCode.ERR_TypeForwardedToMultipleAssemblies, "ClassB.MethodB").WithArguments("CModule.dll", "C, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C.ClassC", "D1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "D2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
         }
 
-        [Fact, WorkItem(16484, "https://github.com/dotnet/roslyn/issues/16484")]
+        [ClrOnlyFact]
+        [WorkItem(16484, "https://github.com/dotnet/roslyn/issues/16484")]
+        [WorkItem(10629, "https://github.com/mono/mono/issues/10629")]
         public void MultipleTypeForwardersToTheSameAssemblyShouldNotResultInMultipleForwardError()
         {
             var codeC = @"

--- a/src/Compilers/Core/MSBuildTaskTests/MapSourceRootTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/MapSourceRootTests.cs
@@ -22,7 +22,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                $" MappedPath='{sourceRoot.GetMetadata("MappedPath")}'" +
                $" SourceLinkUrl='{sourceRoot.GetMetadata("SourceLinkUrl")}'";
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void BasicMapping()
         {
             var engine = new MockEngine();
@@ -72,7 +73,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.True(result);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void InvalidChars()
         {
             var engine = new MockEngine();
@@ -116,7 +118,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.True(result);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void SourceRootPaths_EndWithSeparator()
         {
             var engine = new MockEngine();
@@ -143,7 +146,8 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
             Assert.False(result);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void NestedRoots_Separators()
         {
             var engine = new MockEngine();
@@ -193,7 +197,8 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
             Assert.True(result);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void SourceRootCaseSensitive()
         {
             var engine = new MockEngine();
@@ -227,7 +232,8 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
             Assert.True(result);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void Error_Recursion()
         {
             var engine = new MockEngine();
@@ -344,7 +350,8 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
             Assert.True(result);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void Error_MissingContainingRoot()
         {
             var engine = new MockEngine();
@@ -374,7 +381,8 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
             Assert.False(result);
         }
 
-        [Fact]
+        [ClrOnlyFact]
+        [WorkItem(10678, "https://github.com/mono/mono/issues/10678")]
         public void Error_NoContainingRootSpecified()
         {
             var engine = new MockEngine();

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactsTest.vb
@@ -1000,7 +1000,8 @@ End Namespace
         Assert.Equal(VarianceKind.None, SyntaxFacts.VarianceKindFromToken(keywordToken))
     End Sub
 
-    <Fact>
+    <ClrOnlyFact>
+    <WorkItem(10751, "https://github.com/mono/mono/issues/10751")>
     Public Sub AllowsLeadingOrTrailingImplicitLineContinuation()
 
         Dim cu = SyntaxFactory.ParseCompilationUnit(My.Resources.Resource.VBAllInOne)
@@ -1098,7 +1099,8 @@ End Namespace
 
     End Sub
 
-    <Fact>
+    <ClrOnlyFact>
+    <WorkItem(10751, "https://github.com/mono/mono/issues/10751")>
     Public Sub AllowsLeadingOrTrailingImplicitLineContinuationNegativeTests()
 
         Dim cu = SyntaxFactory.ParseCompilationUnit(My.Resources.Resource.VBAllInOne)

--- a/src/Test/Utilities/Portable/Assert/ClrOnlyFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ClrOnlyFactAttribute.cs
@@ -50,7 +50,11 @@ namespace Roslyn.Test.Utilities
 
             if (MonoHelpers.IsRunningOnMono())
             {
-                Skip = GetSkipReason(Reason);
+                // HACK: We're going to use corecclr ilasm
+                if (reason == ClrOnlyReason.Ilasm)
+                    Skip = null;
+                else
+                    Skip = GetSkipReason(Reason);
             }
         }
 

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -98,6 +98,12 @@ namespace Roslyn.Test.Utilities
         public override string SkipReason => "Test not supported on CoreCLR";
     }
 
+    public class DesktopClrOnly : ExecutionCondition
+    {
+        public override bool ShouldSkip => MonoHelpers.IsRunningOnMono() || !ExecutionConditionUtil.IsDesktop;
+        public override string SkipReason => "Test not supported on Mono or CoreCLR";
+    }
+
     public class NoIOperationValidation : ExecutionCondition
     {
 

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -100,7 +100,7 @@ namespace Roslyn.Test.Utilities
 
     public class DesktopClrOnly : ExecutionCondition
     {
-        public override bool ShouldSkip => MonoHelpers.IsRunningOnMono() || !ExecutionConditionUtil.IsDesktop;
+        public override bool ShouldSkip => MonoHelpers.IsRunningOnMono() || (CoreClrShim.AssemblyLoadContext.Type != null);
         public override string SkipReason => "Test not supported on Mono or CoreCLR";
     }
 


### PR DESCRIPTION
These changes enable a bunch of assemblies (including the csharp semantic tests) and disable a set of tests in various assemblies that no longer pass. These changes also enable the use of coreclr ilasm and enable any tests that were disabled because of incompatibilities with mono's ilasm.