### PR TITLE
Fix System.Xml.dll casing

### DIFF
--- a/src/Compilers/VisualBasic/vbc/vbc.rsp
+++ b/src/Compilers/VisualBasic/vbc/vbc.rsp
@@ -30,7 +30,7 @@
 /r:System.Web.RegularExpressions.dll
 /r:System.Web.Services.dll
 /r:System.Windows.Forms.dll
-/r:System.XML.dll
+/r:System.Xml.dll
 
 /r:System.Workflow.Activities.dll
 /r:System.Workflow.ComponentModel.dll


### PR DESCRIPTION
This fixes an issue when using the VB.NET compiler to build on Linux/macOS. It can't find `System.XML.dll` because the file is named `System.Xml.dll`. I also submitted this as an upstream fix as https://github.com/dotnet/roslyn/pull/29246